### PR TITLE
Fix lock_runtime when called from _LuaObject.__dealloc__. Fixes #27

### DIFF
--- a/lupa/lock.pxi
+++ b/lupa/lock.pxi
@@ -59,6 +59,11 @@ cdef inline bint lock_lock(FastRLock lock, long current_thread, bint blocking) n
     # Note that this function *must* hold the GIL when being called.
     # We just use 'nogil' in the signature to make sure that no Python
     # code execution slips in that might free the GIL
+    if lock is None:
+        # This function can sometimes receive a lock that is already
+        # deallocated (e.g. when called from __dealloc__);
+        # return an error in this case.
+        return 0
 
     if lock._count:
         # locked! - by myself?


### PR DESCRIPTION
`self._runtime` can be in a partially destroyed state during `_LuaObject.__dealloc__`, so `lock_lock` can receive a lock that is already destroyed, and this causes bad things to happen. Checking for this condition fixed #27 for me.
