### PR TITLE
Fix error message in setup.py for cases Lua is not found

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -164,13 +164,10 @@ def find_lua_build(no_luajit=False):
             print("Did not find %s using pkg-config: %s" % (
                 package_name, sys.exc_info()[1]))
 
-    error = ("Neither LuaJIT2 nor Lua 5.1 were found, please install "
-             "the library and its development packages, "
-             "or put a local build into the lupa main directory")
-    if no_luajit:
-        print(error)
-    else:
-        raise RuntimeError(error + " (or pass '--no-luajit' option)")
+    error = ("None of LuaJIT2, Lua 5.1 or Lua 5.2 were found. Please install "
+             "Lua and its development packages, "
+             "or put a local build into the lupa main directory.")
+    print(error)
     return {}
 
 


### PR DESCRIPTION
1. Lua 5.2 is added to error message;
2. `(or pass '--no-luajit' option)` note is removed because passing this option can't (?) make lupa install without Lua available;
3. `library` is changed to `Lua` because it is not clear if "library" is lupa or Lua.
