### PR TITLE
tox.ini: make sure lupa is built with Cython

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,6 @@ envlist=py26,py27,py31,py32,py33,py34
 [testenv]
 deps=Cython
 commands=
-    {envpython} setup.py --quiet build install
+    {envpython} setup.py --with-cython --quiet build install
     {envpython} lupa/tests/test.py
 sitepackages=False


### PR DESCRIPTION
Without this lupa tox tests can be run against outdated C files.
