### PR TITLE
unpacks_lua_table and unpacks_lua_table_method decorators

### DIFF
--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -393,9 +393,10 @@ def unpacks_lua_table(func):
     WARNING: avoid using this decorator for functions which
     first argument can be a Lua table.
 
-    WARNING: be careful with parameter default values and Lua ``nil``:
-    depending on context, passing ``nil`` could mean either
-    "omit a parameter" or "pass None".
+    WARNING: be careful with ``nil`` values: depending on context,
+    passing ``nil`` as a parameter could mean either "omit a parameter"
+    or "pass None"; it also depends on Lua version. It is possible to use
+    ``python.none`` instead of ``nil`` to pass None values robustly.
     """
     def wrapper(*args):
         args, kwargs = _fix_args_kwargs(args)

--- a/lupa/tests/test.py
+++ b/lupa/tests/test.py
@@ -2033,17 +2033,11 @@ class KwargsDecoratorTest(SetupLuaRuntimeMixin, unittest.TestCase):
     def test_posargs_nil(self):
         self.assertResult(self.arg3, "(5, nil, 6)", "x=5, y=None, z=6")
 
-    def test_posargs_nil_last(self):
-        self.assertResult(self.arg3, "(5, nil, nil)", "x=5, y=None, z=None")
-
-    def test_posargs_kwargs_nil(self):
-        self.assertResult(self.arg3, "{5, nil, 6}", "x=5, y=None, z=6")
-
     def test_posargs_nil_first(self):
         self.assertResult(self.arg3, "(nil, nil, 6)", "x=None, y=None, z=6")
 
-    def test_posargs_kwargs_nil_first(self):
-        self.assertResult(self.arg3, "{nil, nil, 6}", "x=None, y=None, z=6")
+    def test_posargs_nil_last(self):
+        self.assertResult(self.arg3, "(5, nil, nil)", "x=5, y=None, z=None")
 
     def test_posargs_kwargs_python_none_last(self):
         self.assertResult(self.arg3, "{5, python.none, python.none}", "x=5, y=None, z=None")
@@ -2057,7 +2051,7 @@ class KwargsDecoratorTest(SetupLuaRuntimeMixin, unittest.TestCase):
     def test_posargs_kwargs_python_none_all(self):
         self.assertResult(self.arg3, "{x=python.none, y=python.none}", "x=None, y=None, z=default")
 
-    # --------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     # The following examples don't work as a Python programmer would expect
     # them to:
 
@@ -2069,6 +2063,15 @@ class KwargsDecoratorTest(SetupLuaRuntimeMixin, unittest.TestCase):
     #
     # def test_posargs_kwargs_nil_all(self):
     #     self.assertResult(self.arg3, "{x=nil, y=nil}", "x=None, y=None, z=default")
+
+    # -------------------------------------------------------------------------
+    # These tests pass in Lua 5.2 but fail in LuaJIT:
+
+    # def test_posargs_kwargs_nil(self):
+    #     self.assertResult(self.arg3, "{5, nil, 6}", "x=5, y=None, z=6")
+    #
+    # def test_posargs_kwargs_nil_first(self):
+    #     self.assertResult(self.arg3, "{nil, nil, 6}", "x=None, y=None, z=6")
 
 
 


### PR DESCRIPTION
This is an implementation of #35. 

It misses:
- README note;
- `table.items()` optimization in `_fix_args_kwargs` helper function;
- a review.
