### PR TITLE
fixed error messages for denied attribute access

### DIFF
--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -1498,7 +1498,7 @@ cdef int py_object_getindex(lua_State* L) nogil:
         return lua.luaL_argerror(L, 1, "not a python object")   # never returns!
     result = py_object_getindex_with_gil(L, py_obj)
     if result < 0:
-        return lua.luaL_error(L, 'error during Python str() call')  # never returns!
+        return lua.luaL_error(L, "reading from a Python attribute is denied")  # never returns!
     return result
 
 
@@ -1520,7 +1520,7 @@ cdef int py_object_setindex(lua_State* L) nogil:
         return lua.luaL_argerror(L, 1, "not a python object")   # never returns!
     result = py_object_setindex_with_gil(L, py_obj)
     if result < 0:
-        return lua.luaL_error(L, 'error during Python str() call')  # never returns!
+        return lua.luaL_error(L, "writing to a Python attribute is denied")  # never returns!
     return result
 
 # special methods for Lua wrapped Python objects


### PR DESCRIPTION
I was getting obscure `[string "<python>"]:4: error during Python str() call` errors. The real error was a denied attribute access caused by custom `attribute_handlers`: `attr_getter` raised an AttributeError. 

What I haven't yet understood is why aren't AttributeErrors reraised in my case. In simple examples they are reraised. The code is quite hairy, it uses coroutines and throws Python exceptions. I haven't extracted a small test case from it yet. Any ideas? 

But it seems that error messages worth fixing anyways.
