### PR TITLE
fixed an error with callbacks returned from wrapped Lua coroutines

### DIFF
--- a/lupa/lua.pxd
+++ b/lupa/lua.pxd
@@ -150,7 +150,7 @@ cdef extern from "lua.h" nogil:
 
     # coroutine functions
     int  lua_yield (lua_State *L, int nresults)
-    int  lua_resume "__lupa_lua_resume" (lua_State *L, int narg)
+    int  lua_resume "__lupa_lua_resume" (lua_State *L, lua_State *from_, int narg)
     int  lua_status (lua_State *L)
 
     # garbage-collection function and options

--- a/lupa/lupa_defs.h
+++ b/lupa/lupa_defs.h
@@ -3,12 +3,12 @@
  */
 
 #if LUA_VERSION_NUM >= 502
-#define __lupa_lua_resume(L, nargs)   lua_resume(L, NULL, nargs)
-#define lua_objlen(L, i)              lua_rawlen(L, (i))
+#define __lupa_lua_resume(L, from_, nargs)   lua_resume(L, from_, nargs)
+#define lua_objlen(L, i)                     lua_rawlen(L, (i))
 
 #else
 #if LUA_VERSION_NUM >= 501
-#define __lupa_lua_resume(L, nargs)   lua_resume(L, nargs)
+#define __lupa_lua_resume(L, from_, nargs)   lua_resume(L, nargs)
 
 #else
 #error Lupa requires at least Lua 5.1 or LuaJIT 2.x

--- a/lupa/tests/test.py
+++ b/lupa/tests/test.py
@@ -1425,19 +1425,23 @@ class TestLuaCoroutinesWithDebugHooks(SetupLuaRuntimeMixin, unittest.TestCase):
                 coroutine.yield()
             end
         ''')
-        def _check():
-            dct = {}
+        def _check(dct):
             coro = self.lua.eval('func').coroutine(dct)
             next(coro)
             cb = dct['cb']
             self.assertEqual(cb(), 123)
 
         # sending a callback should work without a debug hook
-        _check()
+        _check({})
 
         # enable debug hook and try again
         self._enable_hook()
-        _check()
+
+        # it works with a Lua table wrapper
+        _check(self.lua.table_from({}))
+
+        # FIXME: but it fails with a regular dict
+        # _check({})
 
     def test_coroutine_sets_callback_debug_hook_nowrap(self):
         resume = self.lua.eval("coroutine.resume")


### PR DESCRIPTION
I've got an obscure LuaError when trying to use a callback yielded from a coroutine when a debug hook is enabled. 

It boils down to `resume_lua_thread` implementation which doesn't match coroutine.resume. Check the tests: `test_coroutine_yields_callback_debug_hook_nowrap` which uses coroutine.resume passes in lupa 1.1, but `test_coroutine_yields_callback_debug_hook` fails.

This is fixed by bringing implementation closer to [auxresume](http://www.lua.org/source/5.2/lcorolib.c.html). 

The main difference is that now a Lua function yielded by a coroutine gets 'main' state (not coroutine's state) as its state. This makes test pass in Lua 5.2.