### PR TITLE
Add pkg-config to OS X installation instructions

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -125,6 +125,10 @@ OS X + Lua 5.2 + Homebrew
 
      $ brew install lua
 
+#) Install pkg-config::
+
+     $ brew install pkg-config
+
 #) Install lupa::
 
      $ pip install lupa


### PR DESCRIPTION
During installation on Mac OS X `pip install lupa` log contained lots of errors like 

```
    Checking for installed lua5.2 library using pkg-config
    Did not find lua5.2 using pkg-config: /bin/sh: pkg-config: command not found
```

lupa was installed successfully according to pip

```
    11 warnings generated.
    clang -bundle -undefined dynamic_lookup -L/usr/local/lib -L/usr/local/opt/sqlite/lib build/temp.macosx-10.10-x86_64-2.7/lupa/_lupa.o -o build/lib.macosx-10.10-x86_64-2.7/lupa/_lupa.so

Successfully installed lupa
```

but it didn't work for an [application](http://splash.readthedocs.org/en/latest/kernel.html) I was going to use it

```
➜  ~  python -m splash.kernel install
dyld: lazy symbol binding failed: Symbol not found: _luaL_newstate
  Referenced from: /usr/local/lib/python2.7/site-packages/lupa/_lupa.so
  Expected in: flat namespace

dyld: Symbol not found: _luaL_newstate
  Referenced from: /usr/local/lib/python2.7/site-packages/lupa/_lupa.so
  Expected in: flat namespace

[1]    13733 trace trap  python -m splash.kernel install
``` 

after `brew install pkg-config` everything worked out
