### PR TITLE
TST fix Travis build for Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: 2.7
+python: 3.5
 
 env:
 - TOXENV=py26 LUA=libluajit-5.1-dev


### PR DESCRIPTION
By default there is no Python 3.5 installed on Travis, so tests fail.
Travis installs it if we ask Travis to run tox using Python 3.5.