### PR TITLE
fixed calling __str__ in Python 3 when encoding is None

### DIFF
--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -1424,7 +1424,7 @@ cdef int py_str_with_gil(lua_State* L, py_object* py_obj) with gil:
         runtime = <LuaRuntime?>py_obj.runtime
         s = str(<object>py_obj.obj)
         if isinstance(s, unicode):
-            s = (<unicode>s).encode(runtime._encoding)
+            s = (<unicode>s).encode(runtime._encoding or 'UTF-8')
         else:
             assert isinstance(s, bytes)
         lua.lua_pushlstring(L, <bytes>s, len(<bytes>s))

--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -1424,7 +1424,10 @@ cdef int py_str_with_gil(lua_State* L, py_object* py_obj) with gil:
         runtime = <LuaRuntime?>py_obj.runtime
         s = str(<object>py_obj.obj)
         if isinstance(s, unicode):
-            s = (<unicode>s).encode(runtime._encoding or 'UTF-8')
+            if runtime._encoding is None:
+                s = (<unicode>s).encode('UTF-8')
+            else:
+                s = (<unicode>s).encode(runtime._encoding)
         else:
             assert isinstance(s, bytes)
         lua.lua_pushlstring(L, <bytes>s, len(<bytes>s))

--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -47,7 +47,7 @@ except ImportError:
     import builtins
 
 DEF POBJECT = b"POBJECT" # as used by LunaticPython
-
+cdef int PY2 = PY_MAJOR_VERSION == 2
 
 cdef enum WrappedObjectFlags:
     # flags that determine the behaviour of a wrapped object:
@@ -102,7 +102,7 @@ def lua_type(obj):
             return 'userdata'
         else:
             lua_type_name = lua.lua_typename(L, ltype)
-            return lua_type_name.decode('ascii') if PY_MAJOR_VERSION >= 3 else lua_type_name
+            return lua_type_name if PY2 else lua_type_name.decode('ascii')
     finally:
         lua.lua_settop(L, old_top)
         unlock_runtime(lua_object._runtime)
@@ -440,6 +440,7 @@ cdef tuple _fix_args_kwargs(tuple args):
         return args, {}
 
     table = <_LuaTable>arg
+    encoding = table._runtime._source_encoding
 
     # arguments with keys from 1 to #tbl are passed as positional
     new_args = [
@@ -449,7 +450,8 @@ cdef tuple _fix_args_kwargs(tuple args):
 
     # arguments with non-integer keys are passed as named
     new_kwargs = {
-        key: value for key, value in _LuaIter(table, ITEMS)
+        (<bytes>key).decode(encoding) if not PY2 and isinstance(key, bytes) else key: value
+        for key, value in _LuaIter(table, ITEMS)
         if not isinstance(key, (int, long))
     }
     return new_args, new_kwargs
@@ -1136,7 +1138,7 @@ cdef int py_to_lua(LuaRuntime runtime, lua_State *L, object o, bint wrap_none=Fa
     elif isinstance(o, long):
         lua.lua_pushnumber(L, <lua.lua_Number>cpython.long.PyLong_AsDouble(o))
         pushed_values_count = 1
-    elif PY_MAJOR_VERSION < 3 and isinstance(o, int):
+    elif PY2 and isinstance(o, int):
         lua.lua_pushnumber(L, <lua.lua_Number><long>o)
         pushed_values_count = 1
     elif isinstance(o, bytes):
@@ -1474,6 +1476,8 @@ cdef int getattr_for_lua(LuaRuntime runtime, lua_State* L, py_object* py_obj, in
         return py_to_lua(runtime, L, value)
     if runtime._attribute_filter is not None:
         attr_name = runtime._attribute_filter(obj, attr_name, False)
+    if isinstance(attr_name, bytes):
+        attr_name = (<bytes>attr_name).decode(runtime._source_encoding)
     return py_to_lua(runtime, L, getattr(obj, attr_name))
 
 cdef int setattr_for_lua(LuaRuntime runtime, lua_State* L, py_object* py_obj, int key_n, int value_n) except -1:
@@ -1485,6 +1489,8 @@ cdef int setattr_for_lua(LuaRuntime runtime, lua_State* L, py_object* py_obj, in
     else:
         if runtime._attribute_filter is not None:
             attr_name = runtime._attribute_filter(obj, attr_name, True)
+        if isinstance(attr_name, bytes):
+            attr_name = (<bytes>attr_name).decode(runtime._source_encoding)
         setattr(obj, attr_name, attr_value)
     return 0
 

--- a/lupa/tests/test.py
+++ b/lupa/tests/test.py
@@ -835,6 +835,29 @@ class TestAttributesNoAutoEncoding(SetupLuaRuntimeMixin, unittest.TestCase):
         self.assertEqual(123, t.ATTR)
 
 
+class TestStrNoAutoEncoding(SetupLuaRuntimeMixin, unittest.TestCase):
+    lua_runtime_kwargs = {'encoding': None}
+
+    def test_call_str(self):
+        self.assertEqual(b"test-None", self.lua.eval('"test-" .. tostring(python.none)'))
+
+    def test_call_str_py(self):
+        function = self.lua.eval('function(x) return "test-" .. tostring(x) end')
+        self.assertEqual(b"test-nil", function(None))
+        self.assertEqual(b"test-1", function(1))
+
+    def test_call_str_class(self):
+        called = [False]
+        class test(object):
+            def __str__(self):
+                called[0] = True
+                return 'STR!!'
+
+        function = self.lua.eval('function(x) return "test-" .. tostring(x) end')
+        self.assertEqual(b"test-STR!!", function(test()))
+        self.assertEqual(True, called[0])
+
+
 class TestAttributeHandlers(unittest.TestCase):
     def setUp(self):
         self.lua = lupa.LuaRuntime()


### PR DESCRIPTION
In Python 3 `__str__` returns unicode, so `(<unicode>s).encode(runtime._encoding)` raises an error when encoding is None (`TypeError: expected bytes, NoneType found`). This is fixed by falling back to UTF-8: it can represent all unicode data and that's what `_LuaObject` uses in its `__str__` when encoding is None.

This PR includes all changes from https://github.com/scoder/lupa/pull/63.