### PR TITLE
Use tox-travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,27 @@
 language: python
-python: 3.5
+python:
+  - 3.5
+  - 3.4
+  - 3.3
+  - 3.2
+  - 2.7
+  - 2.6
+
+addons:
+  apt:
+    packages:
+      - libluajit-5.1-dev
+      - liblua5.2-dev
 
 env:
-- TOXENV=py26 LUA=libluajit-5.1-dev
-- TOXENV=py27 LUA=libluajit-5.1-dev
-- TOXENV=py32 LUA=libluajit-5.1-dev
-- TOXENV=py33 LUA=libluajit-5.1-dev
-- TOXENV=py34 LUA=libluajit-5.1-dev
-- TOXENV=py35 LUA=libluajit-5.1-dev
-- TOXENV=py26 LUA=lua5.2-dev
-- TOXENV=py27 LUA=lua5.2-dev
-- TOXENV=py32 LUA=lua5.2-dev
-- TOXENV=py33 LUA=lua5.2-dev
-- TOXENV=py34 LUA=lua5.2-dev
-- TOXENV=py35 LUA=lua5.2-dev
+  - LUA=luajit-5.1
+  - LUA=lua5.2
 
 install:
-- sudo apt-get install $LUA
-- pip install -U tox
+  # virtualenv<14.0.0 is needed for Python 3.2 support
+  - pip install -U tox-travis "virtualenv<14.0.0"
+
+before_script:
+  - if [[ "$LUA" == "lua5.2" ]]; then export SETUP_OPTIONS="--no-luajit" ; fi
 
 script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,9 @@ envlist=
 deps=
     Cython
     setuptools
+passenv=
+    SETUP_OPTIONS
 commands=
-    {envpython} setup.py --with-cython --quiet build install
+    {envpython} setup.py --with-cython {env:SETUP_OPTIONS:} build install
     {envpython} setup.py test
 sitepackages=False


### PR DESCRIPTION
Moves the jobs onto the Travis container-based infrastructure,
and allows multiple jobs to run concurrently for much lower
elapsed build time for all platforms.

Also fixes the py32 build breakage caused by virtualenv 14.0.0

Do not activate -quiet mode by default; it can now be
customised using environment variable SETUP_OPTIONS