### PR TITLE
Enable Travis pip caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,14 @@ env:
   - LUA=luajit-5.1
   - LUA=lua5.2
 
-install:
+cache: pip
+
+# requirements.txt are automatically installed during 'install' phase.
+
+before_script:
   # virtualenv<14.0.0 is needed for Python 3.2 support
   - pip install -U tox-travis "virtualenv<14.0.0"
 
-before_script:
   - if [[ "$LUA" == "lua5.2" ]]; then export SETUP_OPTIONS="--no-luajit" ; fi
 
 script: tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Cython
+setuptools


### PR DESCRIPTION
When there is no 'install' block, Travis automatically
installs the dependencies in requirements.txt.