### PR TITLE
Don't reraise python exception in case it has been intercepted in lua

### DIFF
--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -1267,8 +1267,14 @@ cdef object execute_lua_call(LuaRuntime runtime, lua_State *L, Py_ssize_t nargs)
     # call into Lua
     with nogil:
         result_status = lua.lua_pcall(L, nargs, lua.LUA_MULTRET, 0)
-    #runtime.reraise_on_exception()
     if result_status:
+        python_errors = (
+            'error reading Python attribute/item',
+            'error during Python call',
+        )
+        for python_error in python_errors:
+            if lua.lua_tostring(L, -1).endswith(python_error):
+                runtime.reraise_on_exception()
         raise_lua_error(runtime, L, result_status)
     return unpack_lua_results(runtime, L)
 

--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -1265,7 +1265,7 @@ cdef object execute_lua_call(LuaRuntime runtime, lua_State *L, Py_ssize_t nargs)
     # call into Lua
     with nogil:
         result_status = lua.lua_pcall(L, nargs, lua.LUA_MULTRET, 0)
-    runtime.reraise_on_exception()
+    #runtime.reraise_on_exception()
     if result_status:
         raise_lua_error(runtime, L, result_status)
     return unpack_lua_results(runtime, L)

--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -240,19 +240,6 @@ cdef class LuaRuntime:
         return 0
 
     @cython.final
-    cdef int warning_on_exception(self) except -1:
-        if self._raised_exception is not None:
-            warnings.warn(
-                u'Python exception occured\n%s' % (
-                    u''.join(traceback.format_exception(
-                        *self._raised_exception,
-                    )),
-                ),
-                RuntimeWarning,
-            )
-        return 0
-
-    @cython.final
     cdef int store_raised_exception(self) except -1:
         self._raised_exception = exc_info()
         return 0
@@ -1290,7 +1277,6 @@ cdef object execute_lua_call(LuaRuntime runtime, lua_State *L, Py_ssize_t nargs)
         for python_error in python_errors:
             if lua.lua_tostring(L, -1).endswith(python_error):
                 runtime.reraise_on_exception()
-            runtime.warning_on_exception()
         raise_lua_error(runtime, L, result_status)
     return unpack_lua_results(runtime, L)
 

--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -5,8 +5,6 @@ A fast Python wrapper around Lua and LuaJIT2.
 """
 
 from __future__ import absolute_import
-import warnings
-import traceback
 
 cimport cython
 

--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -1536,8 +1536,9 @@ cdef int py_object_setindex_with_gil(lua_State* L, py_object* py_obj) with gil:
         else:
             return setattr_for_lua(runtime, L, py_obj, 2, 3)
     except:
-        try: runtime.store_raised_exception()
-        finally: return -1
+        runtime.store_raised_exception()
+        py_to_lua(runtime, L, runtime._raised_exception[1])
+        return -1
 
 cdef int py_object_setindex(lua_State* L) nogil:
     cdef py_object* py_obj = unwrap_lua_object(L, 1) # may not return on error!
@@ -1545,7 +1546,7 @@ cdef int py_object_setindex(lua_State* L) nogil:
         return lua.luaL_argerror(L, 1, "not a python object")   # never returns!
     result = py_object_setindex_with_gil(L, py_obj)
     if result < 0:
-        return lua.luaL_error(L, 'error writing Python attribute/item')  # never returns!
+        return lua.lua_error(L)  # never returns!
     return result
 
 # special methods for Lua wrapped Python objects

--- a/lupa/tests/test.py
+++ b/lupa/tests/test.py
@@ -754,6 +754,28 @@ class TestLuaRuntime(SetupLuaRuntimeMixin, unittest.TestCase):
             raise ValueError("huhu")
         self.assertRaises(ValueError, function, test)
 
+    def test_reraise_pcall(self):
+        function = self.lua.eval(
+            'function(p) local r, err = pcall(p); return r, err end'
+        )
+        self.assertEqual(
+            function(lambda: 5/0),
+            (False, "error during Python call")
+        )
+
+    def test_lua_error_after_intercepted_python_exception(self):
+        function = self.lua.eval('''
+            function(p)
+                pcall(p)
+                print(a.b);
+            end
+        ''')
+        self.assertRaises(
+            lupa.LuaError,
+            function,
+            lambda: 5/0,
+        )
+
     def test_attribute_filter(self):
         def attr_filter(obj, name, setting):
             if isinstance(name, unicode_type):

--- a/lupa/tests/test.py
+++ b/lupa/tests/test.py
@@ -755,12 +755,15 @@ class TestLuaRuntime(SetupLuaRuntimeMixin, unittest.TestCase):
         self.assertRaises(ValueError, function, test)
 
     def test_reraise_pcall(self):
+        exception = Exception('test')
+        def py_function():
+            raise exception
         function = self.lua.eval(
             'function(p) local r, err = pcall(p); return r, err end'
         )
         self.assertEqual(
-            function(lambda: 5/0),
-            (False, "error during Python call")
+            function(py_function),
+            (False, exception)
         )
 
     def test_lua_error_after_intercepted_python_exception(self):


### PR DESCRIPTION
The discussion of the problem can be found here: http://www.freelists.org/post/lupa-dev/Python-exception-reraising-leads-to-ambiguity

I've added the warning as has been asked, but it does not look very convenient to me to actually have it because it tears the tests output apart. We could try to set up filtering though.

Please let me know if anything else is needed for this to be merged.

Thanks!
