### PR TITLE
Add lua51.dll to package for installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 
 import sys
+import shutil
 import os
 
 from glob import iglob
@@ -240,7 +241,10 @@ write_file(os.path.join('lupa', 'version.py'), "__version__ = '%s'\n" % VERSION)
 
 if config.get('libfile'):
     # include lua51.dll in the lib folder if we are on windows
-    extra_setup_args['package_data'] = {'lupa': [config['libfile']]}
+    libfile = config.get('libfile')
+    dllfile = libfile.rsplit(".", 1)[0] + ".dll"
+    shutil.copy(os.path.join(config['include_dirs'][0], dllfile), 'lupa/')
+    extra_setup_args['package_data'] = {'lupa': [dllfile]}
 
 
 # call distutils


### PR DESCRIPTION
This is so that you don't have to have a system-wide LuaJIT DLL on Windows, which allows one to have multiple versions of Python, using multiple versions of lupa/LuaJIT, compiled for separate architectures.

Wheels work too.