### PR TITLE
Call python with the same state as lua was trying to call it. This wa…

### DIFF
--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -1399,13 +1399,11 @@ cdef bint call_python(LuaRuntime runtime, lua_State *L, py_object* py_obj) excep
 
 cdef int py_call_with_gil(lua_State* L, py_object *py_obj) with gil:
     cdef LuaRuntime runtime = None
-    cdef lua_State* stored_state
-    updated_state = False
+    cdef lua_State* stored_state = NULL
 
     try:
         runtime = <LuaRuntime?>py_obj.runtime
         if runtime._state is not L:
-            updated_state = True
             stored_state = runtime._state
             runtime._state = L
         return call_python(runtime, L, py_obj)
@@ -1413,7 +1411,7 @@ cdef int py_call_with_gil(lua_State* L, py_object *py_obj) with gil:
         try: runtime.store_raised_exception()
         finally: return -1
     finally:
-        if updated_state:
+        if stored_state is not NULL:
             runtime._state = stored_state
 
 cdef int py_object_call(lua_State* L) nogil:

--- a/lupa/tests/test.py
+++ b/lupa/tests/test.py
@@ -827,7 +827,7 @@ class TestLuaRuntime(SetupLuaRuntimeMixin, unittest.TestCase):
            return thread;
         end''')
         t = create_thread(f)()
-        self.assertEqual(lua.eval('coroutine.resume(...)', t), (True, b'()'))
+        self.assertEqual(lua.eval('coroutine.resume(...)', t), (True, '()'))
 
     def test_call_from_coroutine2(self):
         lua = self.lua
@@ -839,7 +839,7 @@ class TestLuaRuntime(SetupLuaRuntimeMixin, unittest.TestCase):
              coroutine.yield(f());
            end
         ''').coroutine(f)
-        self.assertEqual(lua.eval('coroutine.resume(...)', t, f), (True, b'()'))
+        self.assertEqual(lua.eval('coroutine.resume(...)', t, f), (True, '()'))
 
 
 class TestAttributesNoAutoEncoding(SetupLuaRuntimeMixin, unittest.TestCase):

--- a/lupa/tests/test.py
+++ b/lupa/tests/test.py
@@ -827,7 +827,7 @@ class TestLuaRuntime(SetupLuaRuntimeMixin, unittest.TestCase):
            return thread;
         end''')
         t = create_thread(f)()
-        self.assertEqual(lua.eval('coroutine.resume(...)', t), (True, u'()'))
+        self.assertEqual(lua.eval('coroutine.resume(...)', t), (True, b'()'))
 
     def test_call_from_coroutine2(self):
         lua = self.lua
@@ -839,7 +839,7 @@ class TestLuaRuntime(SetupLuaRuntimeMixin, unittest.TestCase):
              coroutine.yield(f());
            end
         ''').coroutine(f)
-        self.assertEqual(lua.eval('coroutine.resume(...)', t, f), (True, u'()'))
+        self.assertEqual(lua.eval('coroutine.resume(...)', t, f), (True, b'()'))
 
 
 class TestAttributesNoAutoEncoding(SetupLuaRuntimeMixin, unittest.TestCase):


### PR DESCRIPTION
Initial discussion is here: http://www.freelists.org/post/lupa-dev/luaeval-returns-an-extra-value-if-being-run-from-coroutine

So I've identified the problem: when lua tries to call python from another thread, it uses a different state. But if python tries to call lua back, lupa uses the initial one. The commit stores a new stack in runtime in case it has been changed. This way lua.eval works consistently across the use cases. I'm not sure if it can lead to any race conditions but I could not come up with any possible reasons for that. Also, probably, it's not too nice to update runtime._state each time, if you know a better solution, please tell.