### PR TITLE
build wheels on appveyor

### DIFF
--- a/.appveyor.ps1
+++ b/.appveyor.ps1
@@ -1,0 +1,56 @@
+$ErrorActionPreference = "Stop"
+
+# consts
+$luatar = 'LuaJIT-2.0.5.zip'
+$luadir = 'LuaJIT-2.0.5'
+$pyversion = (python -c "print(__import__('sys').version)")
+if($pyversion.Contains('32 bit')){
+    $arch = 'x86'
+}else{
+    $arch = 'x64'
+}
+$vcvarsall = (Join-Path $env:VS140COMNTOOLS '..' '..' 'VC' 'vcvarsall.bat')
+
+# clean
+Remove-Item -Recurse $luadir, 'build', 'lupa.egg-info', 'backup' -ErrorAction SilentlyContinue
+if($args[0] -eq 'clean'){
+    Exit
+}elseif($args[0] -eq 'distclean'){
+    Remove-Item -Recurse 'dist', $luatar -ErrorAction SilentlyContinue
+    Exit
+}
+
+# print info
+Write-Host ('building for ' + (python --version) + ' ' + $arch) -ForegroundColor Magenta
+
+# get lua tar
+if((Test-Path $luatar) -eq $false){
+    Invoke-WebRequest 'http://luajit.org/download/LuaJIT-2.0.5.zip' -OutFile $luatar
+}
+if((Get-FileHash $luatar -Algorithm MD5).Hash -ne 'f7cf52a049d74aee4e624bdc1160b80d'.ToUpper()){
+    throw 'MD5 mismatch'
+}
+Expand-Archive $luatar -DestinationPath .
+
+# build lua
+$origin_pwd = (Get-Location)
+Set-Location (Join-Path $luadir 'src')
+& $env:ComSpec /c "call `"$vcvarsall`" $arch && msvcbuild.bat"
+Set-Location $origin_pwd
+
+# build lupa
+if(Test-Path 'dist'){
+    Move-Item 'dist' 'backup'
+}
+pip install -r requirements.txt
+pip install wheel
+python setup.py bdist_wheel
+pip install @(Get-ChildItem dist\*.whl)[0] -U
+if(Test-Path 'backup'){
+    Move-Item backup\*.whl 'dist' -ErrorAction SilentlyContinue
+    Remove-Item -Recurse 'backup'
+}
+
+# test lupa
+python setup.py test
+Exit $lastexitcode

--- a/.appveyor.ps1
+++ b/.appveyor.ps1
@@ -9,7 +9,7 @@ if($pyversion.Contains('32 bit')){
 }else{
     $arch = 'x64'
 }
-$vcvarsall = (Join-Path $env:VS140COMNTOOLS '..' '..' 'VC' 'vcvarsall.bat')
+$vcvarsall = "$env:VS140COMNTOOLS\..\..\VC\vcvarsall.bat"
 
 # clean
 Remove-Item -Recurse $luadir, 'build', 'lupa.egg-info', 'backup' -ErrorAction SilentlyContinue
@@ -34,7 +34,7 @@ Expand-Archive $luatar -DestinationPath .
 
 # build lua
 $origin_pwd = (Get-Location)
-Set-Location (Join-Path $luadir 'src')
+Set-Location "$luadir\src"
 & $env:ComSpec /c "call `"$vcvarsall`" $arch && msvcbuild.bat"
 Set-Location $origin_pwd
 
@@ -44,7 +44,7 @@ if(Test-Path 'dist'){
 }
 pip install -r requirements.txt
 pip install wheel
-python setup.py bdist_wheel
+& $env:ComSpec /c 'python setup.py bdist_wheel 2>&1'
 pip install @(Get-ChildItem dist\*.whl)[0] -U
 if(Test-Path 'backup'){
     Move-Item backup\*.whl 'dist' -ErrorAction SilentlyContinue
@@ -53,7 +53,7 @@ if(Test-Path 'backup'){
 
 # test lupa
 Set-Location 'lupa\tests'
-python __init__.py
+& $env:ComSpec /c 'python __init__.py 2>&1'
 $testexitcode = $lastexitcode
-Set-Location (Join-Path '..' '..')
+Set-Location "..\.."
 Exit $testexitcode

--- a/.appveyor.ps1
+++ b/.appveyor.ps1
@@ -29,7 +29,7 @@ if($pyversion.Contains('MSC v.1500')){
 $vcvarsall = "$comntools\..\..\VC\vcvarsall.bat"
 
 # clean
-Remove-Item -Recurse $luadir, 'build', 'lupa.egg-info', 'backup' -ErrorAction SilentlyContinue
+Remove-Item -Recurse $luadir, 'build', 'lupa.egg-info', 'backup', 'lupa\_lupa.c' -ErrorAction SilentlyContinue
 if($args[0] -eq 'clean'){
     Exit
 }elseif($args[0] -eq 'distclean'){

--- a/.appveyor.ps1
+++ b/.appveyor.ps1
@@ -53,7 +53,7 @@ if(Test-Path 'backup'){
 
 # test lupa
 Set-Location 'lupa\tests'
-python test.py
+python __init__.py
 $testexitcode = $lastexitcode
 Set-Location (Join-Path '..' '..')
 Exit $testexitcode

--- a/.appveyor.ps1
+++ b/.appveyor.ps1
@@ -52,5 +52,8 @@ if(Test-Path 'backup'){
 }
 
 # test lupa
-python setup.py test
-Exit $lastexitcode
+Set-Location 'lupa\tests'
+python test.py
+$testexitcode = $lastexitcode
+Set-Location (Join-Path '..' '..')
+Exit $testexitcode

--- a/.appveyor.ps1
+++ b/.appveyor.ps1
@@ -12,7 +12,7 @@ $pyversion = (python -c "print(__import__('sys').version)")
 if($pyversion.Contains('32 bit')){
     $arch = 'x86'
 }else{
-    $arch = 'x64'
+    $arch = 'x86_amd64'
 }
 if($pyversion.Contains('MSC v.1500')){
     # CPython 2.6, 2.7, 3.0, 3.1, 3.2

--- a/.appveyor.ps1
+++ b/.appveyor.ps1
@@ -75,4 +75,6 @@ Set-Location 'lupa\tests'
 run 'python __init__.py'
 $testexitcode = $lastexitcode
 Set-Location "..\.."
-Exit $testexitcode
+if($testexitcode -ne 0){
+    throw 'Test fail'
+}

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,8 +1,5 @@
 build_script:
-  - ps: .\.pyenv.ps1 C:\Python35 .\.appveyor.ps1
-  - ps: .\.pyenv.ps1 C:\Python35-x64 .\.appveyor.ps1
-  - ps: .\.pyenv.ps1 C:\Python36 .\.appveyor.ps1
-  - ps: .\.pyenv.ps1 C:\Python36-x64 .\.appveyor.ps1
+  - ps: Get-ChildItem C:\Python* | ForEach-Object {.\.pyenv.ps1 ('C:\' + $_.Name) .\.appveyor.ps1}
 artifacts:
   - path: dist\*.whl
     name: wheels

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,12 @@
 build_script:
-  - ps: Get-ChildItem C:\Python* | ForEach-Object {.\.pyenv.ps1 ('C:\' + $_.Name) .\.appveyor.ps1}
+  - ps: .\.pyenv.ps1 C:\Python26 .\.appveyor.ps1
+  - ps: .\.pyenv.ps1 C:\Python27 .\.appveyor.ps1
+  - ps: .\.pyenv.ps1 C:\Python33 .\.appveyor.ps1
+  - ps: .\.pyenv.ps1 C:\Python34 .\.appveyor.ps1
+  - ps: .\.pyenv.ps1 C:\Python35 .\.appveyor.ps1
+  - ps: .\.pyenv.ps1 C:\Python35-x64 .\.appveyor.ps1
+  - ps: .\.pyenv.ps1 C:\Python36 .\.appveyor.ps1
+  - ps: .\.pyenv.ps1 C:\Python36-x64 .\.appveyor.ps1
 artifacts:
   - path: dist\*.whl
     name: wheels

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,8 @@
+build_script:
+  - ps: .\.pyenv.ps1 C:\Python35 .\.appveyor.ps1
+  - ps: .\.pyenv.ps1 C:\Python35-x64 .\.appveyor.ps1
+  - ps: .\.pyenv.ps1 C:\Python36 .\.appveyor.ps1
+  - ps: .\.pyenv.ps1 C:\Python36-x64 .\.appveyor.ps1
+artifacts:
+  - path: dist\*.whl
+    name: wheels

--- a/.pyenv.ps1
+++ b/.pyenv.ps1
@@ -1,0 +1,24 @@
+$ErrorActionPreference = "Stop"
+
+$safe_paths = @()
+$origin_path = $env:Path
+$env:Path.Split(';') | ForEach-Object{
+    $env:Path = $_
+    $issafe = $true
+    try{
+        Get-Command 'python' | Out-Null
+        $issafe = $false
+    }catch [System.Management.Automation.CommandNotFoundException]{}
+    try{
+        Get-Command 'pip' | Out-Null
+        $issafe = $false
+    }catch [System.Management.Automation.CommandNotFoundException]{}
+    if($issafe){
+        $safe_paths += $_
+    }
+}
+$env:Path = ((@($args[0], (Join-Path $args[0] 'Scripts')) + $safe_paths) -join ';')
+& $args[1]
+$exitcode = $LASTEXITCODE
+$env:Path = $origin_path
+Exit $exitcode

--- a/.pyenv.ps1
+++ b/.pyenv.ps1
@@ -17,7 +17,7 @@ $env:Path.Split(';') | ForEach-Object{
         $safe_paths += $_
     }
 }
-$env:Path = ((@($args[0], (Join-Path $args[0] 'Scripts')) + $safe_paths) -join ';')
+$env:Path = ((@($args[0], ($args[0] + '\Scripts')) + $safe_paths) -join ';')
 & $args[1]
 $exitcode = $LASTEXITCODE
 $env:Path = $origin_path

--- a/README.rst
+++ b/README.rst
@@ -916,10 +916,10 @@ following should work on a Linux system:
 .. code:: python
 
       >>> import sys
-      >>> orig_dlflags = sys.getdlopenflags()
-      >>> sys.setdlopenflags(258)
+      >>> orig_dlflags = sys.getdlopenflags()     # doctest: +SKIP
+      >>> sys.setdlopenflags(258)                 # doctest: +SKIP
       >>> import lupa
-      >>> sys.setdlopenflags(orig_dlflags)
+      >>> sys.setdlopenflags(orig_dlflags)        # doctest: +SKIP
 
       >>> lua = lupa.LuaRuntime()
       >>> posix_module = lua.require('posix')     # doctest: +SKIP

--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -21,7 +21,10 @@ from cpython.method cimport (
 from cpython.version cimport PY_MAJOR_VERSION
 from cpython.bytes cimport PyBytes_FromFormat
 
-from libc.stdint cimport uintptr_t
+cdef extern from '_stdint.h':
+    # old versions of msvc does not have stdint.h
+    # typedef uintptr_t to unsigned long long -- it might be incorrect, but does not matter
+    ctypedef unsigned long long uintptr_t
 
 cdef extern from *:
     ctypedef char* const_char_ptr "const char*"

--- a/lupa/_stdint.h
+++ b/lupa/_stdint.h
@@ -1,0 +1,64 @@
+/*
+** LuaJIT -- a Just-In-Time Compiler for Lua. http://luajit.org/
+**
+** Copyright (C) 2005-2017 Mike Pall. All rights reserved.
+**
+** Permission is hereby granted, free of charge, to any person obtaining
+** a copy of this software and associated documentation files (the
+** "Software"), to deal in the Software without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Software, and to
+** permit persons to whom the Software is furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be
+** included in all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+**
+** [ MIT license: http://www.opensource.org/licenses/mit-license.php ]
+*/
+
+#ifndef _STDINT_H
+#define _STDINT_H
+
+#if defined(_MSC_VER)
+/* MSVC is stuck in the last century and doesn't have C99's stdint.h. */
+typedef __int8 int8_t;
+typedef __int16 int16_t;
+typedef __int32 int32_t;
+typedef __int64 int64_t;
+typedef unsigned __int8 uint8_t;
+typedef unsigned __int16 uint16_t;
+typedef unsigned __int32 uint32_t;
+typedef unsigned __int64 uint64_t;
+#ifdef _WIN64
+typedef __int64 intptr_t;
+typedef unsigned __int64 uintptr_t;
+#else
+typedef __int32 intptr_t;
+typedef unsigned __int32 uintptr_t;
+#endif
+#elif defined(__symbian__)
+/* Cough. */
+typedef signed char int8_t;
+typedef short int int16_t;
+typedef int int32_t;
+typedef long long int64_t;
+typedef unsigned char uint8_t;
+typedef unsigned short int uint16_t;
+typedef unsigned int uint32_t;
+typedef unsigned long long uint64_t;
+typedef int intptr_t;
+typedef unsigned int uintptr_t;
+#else
+#include <stdint.h>
+#endif
+
+#endif

--- a/lupa/tests/__init__.py
+++ b/lupa/tests/__init__.py
@@ -13,7 +13,7 @@ def suite():
     tests = []
     for filename in os.listdir(test_dir):
         if filename.endswith('.py') and not filename.startswith('_'):
-            tests.append('lupa.tests.'  + filename[:-3])
+            tests.append(('' if os.path.samefile(test_dir, os.getcwd()) else 'lupa.tests.') + filename[:-3])
 
     suite = unittest.defaultTestLoader.loadTestsFromNames(tests)
     suite.addTest(doctest.DocTestSuite(lupa._lupa))

--- a/lupa/tests/__init__.py
+++ b/lupa/tests/__init__.py
@@ -13,7 +13,7 @@ def suite():
     tests = []
     for filename in os.listdir(test_dir):
         if filename.endswith('.py') and not filename.startswith('_'):
-            tests.append(('' if os.path.samefile(test_dir, os.getcwd()) else 'lupa.tests.') + filename[:-3])
+            tests.append(('' if __name__ == '__main__' else 'lupa.tests.') + filename[:-3])
 
     suite = unittest.defaultTestLoader.loadTestsFromNames(tests)
     suite.addTest(doctest.DocTestSuite(lupa._lupa))


### PR DESCRIPTION
this pr contains some auto build scripts for appveyor to build pre-built wheels for Windows, support:

* Python2.6 x86
* Python2.7 x86
* Python3.3 x86
* Python3.4 x86
* Python3.5 x86
* Python3.5 x64
* Python3.6 x86
* Python3.6 x64

note that x64 wheels for python3.4- are not built because of [this issue](https://github.com/appveyor/ci/issues/1699)