### PR TITLE
fix #101

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -294,7 +294,7 @@ if cythonize is not None:
 
 
 def read_file(filename):
-    with open(os.path.join(basedir, filename)) as f:
+    with open(os.path.join(basedir, filename), encoding='utf8') as f:
         return f.read()
 
 


### PR DESCRIPTION
add `encoding='utf8'` to avoid other encoding on Windows