### PR TITLE
Can't import modules on python 3

### DIFF
--- a/lupa/__init__.py
+++ b/lupa/__init__.py
@@ -6,10 +6,10 @@
 def _try_import_with_global_library_symbols():
     try:
         import DLFCN
-        dlopen_flags = DLFCN.RTLD_NOW | DLFCN.RTLD_GLOBAL
     except ImportError:
-        import ctypes
-        dlopen_flags = ctypes.RTLD_GLOBAL
+        import os
+        DLFCN = os
+    dlopen_flags = DLFCN.RTLD_NOW | DLFCN.RTLD_GLOBAL
 
     import sys
     old_flags = sys.getdlopenflags()


### PR DESCRIPTION
use same dlopen flags on python 3 as for python 2 as absence of RTLD_NOW leads to an error: `invalid mode for dlopen(): Invalid argument` and thus it's not longer possible to import modules with lupa