### PR TITLE
Support Python calls with `@lupa.unpacks_lua_table` decorator 

### DIFF
--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -452,7 +452,9 @@ def unpacks_lua_table(func):
     """
     @wraps(func)
     def wrapper(*args):
-        args, kwargs = _fix_args_kwargs(args)
+        kwargs = {}
+        if isinstance(args[0], _LuaTable):
+            args, kwargs = _fix_args_kwargs(args)
         return func(*args, **kwargs)
     return wrapper
 
@@ -464,7 +466,9 @@ def unpacks_lua_table_method(meth):
     """
     @wraps(meth)
     def wrapper(self, *args):
-        args, kwargs = _fix_args_kwargs(args)
+        kwargs = {}
+        if isinstance(args[0], _LuaTable):
+            args, kwargs = _fix_args_kwargs(args)
         return meth(self, *args, **kwargs)
     return wrapper
 

--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -453,7 +453,7 @@ def unpacks_lua_table(func):
     @wraps(func)
     def wrapper(*args):
         kwargs = {}
-        if isinstance(args[0], _LuaTable):
+        if len(args) > 0 and isinstance(args[0], _LuaTable):
             args, kwargs = _fix_args_kwargs(args)
         return func(*args, **kwargs)
     return wrapper
@@ -467,7 +467,7 @@ def unpacks_lua_table_method(meth):
     @wraps(meth)
     def wrapper(self, *args):
         kwargs = {}
-        if isinstance(args[0], _LuaTable):
+        if len(args) > 0 and isinstance(args[0], _LuaTable):
             args, kwargs = _fix_args_kwargs(args)
         return meth(self, *args, **kwargs)
     return wrapper

--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -451,8 +451,7 @@ def unpacks_lua_table(func):
     robustly.
     """
     @wraps(func)
-    def wrapper(*args):
-        kwargs = {}
+    def wrapper(*args, **kwargs):
         if len(args) > 0 and isinstance(args[0], _LuaTable):
             args, kwargs = _fix_args_kwargs(args)
         return func(*args, **kwargs)
@@ -465,8 +464,7 @@ def unpacks_lua_table_method(meth):
     (i.e. it knows about the 'self' argument).
     """
     @wraps(meth)
-    def wrapper(self, *args):
-        kwargs = {}
+    def wrapper(self, *args, **kwargs):
         if len(args) > 0 and isinstance(args[0], _LuaTable):
             args, kwargs = _fix_args_kwargs(args)
         return meth(self, *args, **kwargs)


### PR DESCRIPTION
This pull request now allows functions or methods decorator with `@lupa.unpacks_lua_table` or `@lupa.unpacks_lua_table_method` to be called from Python. Originally if a decorated function or method was called, it would error because of invalid parameters, though this fixes that. It addresses and fixes the problems had with #121 also.

The changes has been tested and passed all checks. 