### PR TITLE
Python exceptions within coroutines are reraised

### DIFF
--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -1294,7 +1294,11 @@ cdef int raise_lua_error(LuaRuntime runtime, lua_State* L, int result) except -1
     elif result == lua.LUA_ERRMEM:
         raise MemoryError()
     else:
-        raise LuaError( build_lua_error_message(runtime, L, None, -1) )
+        error = py_from_lua(runtime, L, 1)
+        if isinstance(error, BaseException):
+            runtime.reraise_on_exception()
+        else:
+            raise LuaError( build_lua_error_message(runtime, L, None, -1) )
 
 cdef build_lua_error_message(LuaRuntime runtime, lua_State* L, unicode err_message, int n):
     cdef size_t size = 0

--- a/lupa/tests/test.py
+++ b/lupa/tests/test.py
@@ -1509,6 +1509,15 @@ class TestLuaCoroutines(SetupLuaRuntimeMixin, unittest.TestCase):
             result.append(_next(gen))
         self.assertEqual([0,1,0,1,0,1], result)
 
+    def test_coroutine_reraises_python_error(self):
+        lua_code = '''\
+        function(test)
+            test()
+        end'''
+        f = self.lua.eval(lua_code)
+        gen = f.coroutine(lambda: int('hello'))
+        self.assertRaises(ValueError, lambda: gen.send(None))
+
 
 class TestLuaCoroutinesWithDebugHooks(SetupLuaRuntimeMixin, unittest.TestCase):
 


### PR DESCRIPTION
Fixes #144.
Currently if a lua coroutine calls Python code which raises an exception, a LuaError will be raised and the original exception will be lost. This isn't consistent with the behavior of non-coroutine code, which is to reraise the exception, and losing the original exception makes it very hard to debug lua coroutines.

A new unit test `test_coroutine_reraises_python_error` has been added.