### PR TITLE
Fixes Python missing references

### DIFF
--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -80,7 +80,6 @@ cdef struct py_object:
     PyObject* obj
     PyObject* runtime
     int type_flags  # or-ed set of WrappedObjectFlags
-    uintptr_t refcount
 
 
 include "lock.pxi"

--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -80,6 +80,7 @@ cdef struct py_object:
     PyObject* obj
     PyObject* runtime
     int type_flags  # or-ed set of WrappedObjectFlags
+    uintptr_t refcount
 
 
 include "lock.pxi"
@@ -1461,6 +1462,7 @@ cdef int py_object_gc(lua_State* L) nogil:
 # calling Python objects
 
 cdef bint call_python(LuaRuntime runtime, lua_State *L, py_object* py_obj) except -1:
+    # here we assume that py_obj and py_obj.obj aren't NULL
     cdef int i, nargs = lua.lua_gettop(L) - 1
     cdef tuple args
 

--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -1258,7 +1258,7 @@ cdef bint py_to_lua_custom(LuaRuntime runtime, lua_State *L, object o, int type_
 
     lua.lua_getfield(L, lua.LUA_REGISTRYINDEX, PYREFST)  # tbl
 
-    # check if python object is already referenced in Lua
+    # check if Python object is already referenced in Lua
     if refkey in runtime._pyrefs_in_lua:
         pyref = <_PyReference>runtime._pyrefs_in_lua[refkey]
         lua.lua_rawgeti(L, -1, pyref._ref)              # tbl udata
@@ -1266,9 +1266,7 @@ cdef bint py_to_lua_custom(LuaRuntime runtime, lua_State *L, object o, int type_
         if py_obj:
             lua.lua_remove(L, -2)                       # udata
             return 1 # values pushed
-        else:
-            lua.lua_pop(L, 1)                           # tbl
-
+        lua.lua_pop(L, 1)                               # tbl
     py_obj = <py_object*>lua.lua_newuserdata(L, sizeof(py_object))
     if not py_obj:
         lua.lua_pop(L, 1)                #
@@ -1462,7 +1460,6 @@ cdef int py_object_gc_with_gil(py_object *py_obj, lua_State* L) with gil:
         pyref = <_PyReference>runtime._pyrefs_in_lua.pop(refkey)
         lua.lua_getfield(L, lua.LUA_REGISTRYINDEX, PYREFST)  # tbl
         lua.luaL_unref(L, -1, pyref._ref)                    # tbl
-        lua.lua_pop(L, 1)                                    #
     except (TypeError, KeyError):
         return 0  # runtime was already cleared during GC, nothing left to do
     except:

--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -1267,6 +1267,7 @@ cdef bint py_to_lua_custom(LuaRuntime runtime, lua_State *L, object o, int type_
             lua.lua_remove(L, -2)                       # udata
             return 1 # values pushed
         lua.lua_pop(L, 1)                               # tbl
+
     py_obj = <py_object*>lua.lua_newuserdata(L, sizeof(py_object))
     if not py_obj:
         lua.lua_pop(L, 1)                #

--- a/lupa/tests/test.py
+++ b/lupa/tests/test.py
@@ -2619,6 +2619,7 @@ class TestErrorStackTrace(unittest.TestCase):
         except lupa.LuaError as e:
             self.assertNotIn("stack traceback:", e.args[0])
 
+
 ################################################################################
 # tests for missing reference
 
@@ -2677,6 +2678,7 @@ class TestMissingReference(SetupLuaRuntimeMixin, unittest.TestCase):
         self.testmissingref({}, lupa.as_itemgetter) # item getter protocol
         self.testmissingref({}, lupa.as_attrgetter) # attribute getter protocol
 
+
 if __name__ == '__main__':
     def print_version():
         version = lupa.LuaRuntime().lua_implementation
@@ -2684,4 +2686,3 @@ if __name__ == '__main__':
 
     print_version()
     unittest.main()
-

--- a/lupa/tests/test.py
+++ b/lupa/tests/test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 import threading
 import operator
@@ -2618,6 +2618,64 @@ class TestErrorStackTrace(unittest.TestCase):
             raise RuntimeError("LuaError was not raised")
         except lupa.LuaError as e:
             self.assertNotIn("stack traceback:", e.args[0])
+
+################################################################################
+# tests for missing reference
+
+class TestMissingReference(SetupLuaRuntimeMixin, unittest.TestCase):
+
+    def setUp(self):
+        super(TestMissingReference, self).setUp()
+        self.testmissingref = self.lua.eval('''
+        function(obj, f)
+            local t
+            if newproxy then
+                local p = newproxy(true)
+                t = getmetatable(p)
+                t.obj = obj
+                t.__gc = function(p_) t = getmetatable(p_) end
+            else
+                t = { obj = obj }
+                setmetatable(t, {__gc = function(t_) t = t_ end})
+            end
+            obj = nil
+            t = nil
+            collectgarbage()
+            assert(t ~= nil)
+            assert(t.obj ~= nil)
+            local ok, ret = pcall(f, t.obj)
+            assert(not ok)
+            assert(tostring(ret):find("deleted python object"))
+        end
+        ''')
+
+    def tearDown(self):
+        self.testmissingref = None
+        super(TestMissingReference, self).tearDown()
+
+    def test_fallbacks(self):
+        class X():
+            def __call__(self, *args):
+                return None
+
+        def assign(var):
+            var = None
+
+        self.testmissingref({}, lambda o: str(o))                            # __tostring
+        self.testmissingref({}, lambda o: o[1])                              # __index
+        self.testmissingref({}, lambda o: lupa.as_itemgetter(o)[1])          # __index (itemgetter)
+        self.testmissingref({}, lambda o: lupa.as_attrgetter(o).items)       # __index (attrgetter)
+        self.testmissingref({}, lambda o: assign(o[1]))                      # __newindex
+        self.testmissingref({}, lambda o: assign(lupa.as_itemgetter(o)[1]))  # __newindex (itemgetter)
+        self.testmissingref(X(), lambda o: assign(lupa.as_attrgetter(o).a))  # __newindex (attrgetter)
+        self.testmissingref(X(), lambda o: o())                              # __call
+
+    def test_functions(self):
+        self.testmissingref({}, print)              # reflection
+        self.testmissingref({}, iter)               # iteration
+        self.testmissingref({}, enumerate)          # enumerate
+        self.testmissingref({}, lupa.as_itemgetter) # item getter protocol
+        self.testmissingref({}, lupa.as_attrgetter) # attribute getter protocol
 
 if __name__ == '__main__':
     def print_version():


### PR DESCRIPTION
* When a Python object in Lua is ressurected, it may result in a missing
reference because its reference count has been zeroed and Python can't
ressurect it like Lua. This would lead to the dangling pointer problem.
The way to solve this is by tagging the Python object in Lua when it is
deallocated so that if it is later accessed, an error is raised.
* Optimized `LuaRuntime._pyrefs_in_lua`: Created the Cython class called
`_PyReference`, which contains the Python object being referenced and
the reference count (from Lua `userdata`)
* Added tests for missing references
* Added `lua_State*` parameter to `_LuaObject.push_lua_object` in order to
call `lua_rawgeti` with the correct Lua state, and substituted calls to
`lua_rawgeti` to `_LuaObject.push_lua_object` because it checks whether the
object is missing!
* Added `unpack_python_argument_or_jump` for checking whether the Python
object is missing and doing a long jump if so. This makes the code less
repetitive too.