### PR TITLE
Fixed build for PyPy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       run: sudo apt-get install lib${{ matrix.lua-version }}-dev
 
     - name: Run tests with tox
-      run: echo "${{ matrix.python-version }}" | tr -d -c '[0-9]' | xargs -i tox -e "py{}"
+      run: tox -e py # Runs the version of Python tox is currently using
       continue-on-error: ${{ contains(matrix.python-version, 'pypy') }}
       env:
         SETUP_OPTIONS: ${{ !contains(matrix.lua-version, 'luajit') && (contains(matrix.lua-version, 'bundle') && '--use-bundle' || '--no-luajit') || '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Set up Python packages
-      run: python -m pip install -U pip tox virtualenv
+      run: python -m pip install -U pip<21 setuptools<45 tox virtualenv
 
     - name: Set up Lua ${{ matrix.lua-version }}
       if: ${{ !contains(matrix.lua-version, 'bundle') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Set up Python packages
-      run: python -m pip install -U pip<21 setuptools<45 tox virtualenv
+      run: python -m pip install -U "pip<21" "setuptools<45" ; python -m pip install -U tox virtualenv
 
     - name: Set up Lua ${{ matrix.lua-version }}
       if: ${{ !contains(matrix.lua-version, 'bundle') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Set up Python packages
-      run: python -m pip install -U tox virtualenv
+      run: python -m pip install -U pip tox virtualenv
 
     - name: Set up Lua ${{ matrix.lua-version }}
       if: ${{ !contains(matrix.lua-version, 'bundle') }}


### PR DESCRIPTION
* tox -e py36 was resolving to CPython 3.6, not PyPy 3.6
* tox -e py now resolves to the version of Python Tox is currently
using! It's also cleaner than that echo-tr-xargs pipe.
* Source: https://tox.readthedocs.io/en/latest/example/basic.html