### PR TITLE
Fix crash on table lookups

### DIFF
--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -744,7 +744,7 @@ cdef class _LuaObject:
                 raise (AttributeError if is_attr_access else TypeError)(
                     "item/attribute access not supported on functions")
             # table[nil] fails, so map None -> python.none for Lua tables
-            py_to_lua(self._runtime, L, name, wrap_none=(lua_type==lua.LUA_TTABLE))  # func obj key
+            py_to_lua(self._runtime, L, name, wrap_none=(lua_type == lua.LUA_TTABLE))  # func obj key
             return execute_lua_call(self._runtime, L, 2)                             # obj[key]
         finally:
             lua.lua_settop(L, old_top)                                               #
@@ -2016,7 +2016,7 @@ cdef void luaL_openlib(lua_State *L, const char *libname,
     else:
         lua.lua_pop(L, nup)
 
-# internal Lua functions meant to be called on protected mode
+# internal Lua functions meant to be called in protected mode
 
 cdef int get_from_lua_table(lua_State* L) nogil:
     """Equivalent to the following Lua function:

--- a/lupa/tests/test.py
+++ b/lupa/tests/test.py
@@ -2632,16 +2632,6 @@ class TestTableAccessError(SetupLuaRuntimeMixin, unittest.TestCase):
         lua_t = self.lua.eval('t')
         self.assertRaises(lupa.LuaError, lambda t, k: t[k], lua_t, 'k')
 
-    def test_error_metatable_index_metamethod(self):
-        self.lua.execute('''
-        mt = {}
-        setmetatable(mt, {__index = function() error() end})
-        t = {}
-        setmetatable(t, mt)
-        ''')
-        lua_t = self.lua.eval('t')
-        self.assertRaises(lupa.LuaError, lambda t, k: t[k], lua_t, 'k')
-
 
 ################################################################################
 # tests for missing reference

--- a/lupa/tests/test.py
+++ b/lupa/tests/test.py
@@ -2619,6 +2619,29 @@ class TestErrorStackTrace(unittest.TestCase):
         except lupa.LuaError as e:
             self.assertNotIn("stack traceback:", e.args[0])
 
+
+################################################################################
+# tests for table access error
+
+class TestTableAccessError(SetupLuaRuntimeMixin, unittest.TestCase):
+    def test_error_index_metamethod(self):
+        self.lua.execute('''
+        t = {}
+        setmetatable(t, {__index = function() error() end})
+        ''')
+        lua_t = self.lua.eval('t')
+        self.assertRaises(lupa.LuaError, lambda t, k: t[k], lua_t, 'k')
+
+    def test_error_metatable_index_metamethod(self):
+        self.lua.execute('''
+        mt = {}
+        setmetatable(mt, {__index = function() error() end})
+        t = {}
+        setmetatable(t, mt)
+        ''')
+        lua_t = self.lua.eval('t')
+        self.assertRaises(lupa.LuaError, lambda t, k: t[k], lua_t, 'k')
+
 if __name__ == '__main__':
     def print_version():
         version = lupa.LuaRuntime().lua_implementation


### PR DESCRIPTION
* Adds `_LuaObject._gettable`, which is a safer version `lua_gettable` which doesn't make long jumps
* Modifies `_LuaObject._getitem` to call `_LuaObject._gettable` instead of `lua_gettable`
* Adds tests for errors thrown by the "index" metamethod

Closes https://github.com/scoder/lupa/issues/174