### PR TITLE
Add python.args function for building keyword argument dicts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Upcoming release
 * The Lua implementation name and version string is provided as
   ``LuaRuntime.lua_implementation``.
 
+* GH#177: Tables that are not sequences raise ``IndexError`` when unpacked.
+
 
 1.9 (2019-12-21)
 ----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,11 @@ Upcoming release
 * The Lua implementation name and version string is provided as
   ``LuaRuntime.lua_implementation``.
 
+* GH#177: A new function ``python.args(*args, **kwargs)`` was added to help with building
+  Python argument tuples and keyword argument dicts for Python function calls from Lua code.
+
 * GH#177: Tables that are not sequences raise ``IndexError`` when unpacked.
+  They previously raised a ``TypeError``.
 
 
 1.9 (2019-12-21)

--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -699,26 +699,6 @@ cdef class _LuaObject:
             raise LuaError("lost reference")
         return 0
 
-    def __eq__(self, o):
-        assert self._runtime is not None
-        if not isinstance(o, _LuaObject):
-            return False
-        cdef lua_State* L = self._state
-        cdef _LuaObject other = <_LuaObject>o
-        if L != other._state:
-            return False
-        lock_runtime(self._runtime)
-        old_top = lua.lua_gettop(L)
-        cdef bint equal = False
-        try:
-            self.push_lua_object(L)
-            other.push_lua_object(L)
-            equal = lua.lua_rawequal(L, -1, -2)
-        finally:
-            lua.lua_settop(L, old_top)
-            unlock_runtime(self._runtime)
-        return equal
-
     def __call__(self, *args):
         assert self._runtime is not None
         cdef lua_State* L = self._state

--- a/lupa/tests/test.py
+++ b/lupa/tests/test.py
@@ -2659,6 +2659,9 @@ class PythonArgumentsInLuaTest(SetupLuaRuntimeMixin, unittest.TestCase):
         lua_func = self.lua.eval('function (f) return f(%s) end' % txt)
         self.assertRaisesRegex(error, regex, lua_func, self.get_none)
 
+    def test_no_table(self):
+        self.assertIncorrect('python.args()', error=lupa.LuaError)
+
     def test_no_args(self):
         self.assertResult('python.args{}', (), {})
 

--- a/lupa/tests/test.py
+++ b/lupa/tests/test.py
@@ -2712,6 +2712,7 @@ class PythonArgumentsInLuaTest(SetupLuaRuntimeMixin, unittest.TestCase):
     def test_kwargs_merge_conflict(self):
         self.assertIncorrect('python.args{a=1}, python.args{a=2}', regex='multiple values')
 
+
 class PythonArgumentsInLuaMethodsTest(PythonArgumentsInLuaTest):
 
     def __init__(self, *args, **kwargs):
@@ -2914,7 +2915,6 @@ class TestMissingReference(SetupLuaRuntimeMixin, unittest.TestCase):
         self.testmissingref({}, enumerate)          # enumerate
         self.testmissingref({}, lupa.as_itemgetter) # item getter protocol
         self.testmissingref({}, lupa.as_attrgetter) # attribute getter protocol
- 
 
 if __name__ == '__main__':
     def print_version():

--- a/lupa/tests/test.py
+++ b/lupa/tests/test.py
@@ -2938,6 +2938,7 @@ class TestMissingReference(SetupLuaRuntimeMixin, unittest.TestCase):
         self.testmissingref({}, lupa.as_itemgetter) # item getter protocol
         self.testmissingref({}, lupa.as_attrgetter) # attribute getter protocol
 
+
 if __name__ == '__main__':
     def print_version():
         version = lupa.LuaRuntime().lua_implementation

--- a/lupa/tests/test.py
+++ b/lupa/tests/test.py
@@ -2627,11 +2627,17 @@ class TestErrorStackTrace(unittest.TestCase):
 
 class PythonArgumentsInLuaTest(SetupLuaRuntimeMixin, unittest.TestCase):
 
-    def __init__(self, *args, **kwargs):
-        super(PythonArgumentsInLuaTest, self).__init__(*args, **kwargs)
-        self.get_args = lambda *args, **kwargs: args
-        self.get_kwargs = lambda *args, **kwargs: kwargs
-        self.get_none = lambda *args, **kwargs: None
+    @staticmethod
+    def get_args(*args, **kwargs):
+        return args
+
+    @staticmethod
+    def get_kwargs(*args, **kwargs):
+        return kwargs
+
+    @staticmethod
+    def get_none(*args, **kwargs):
+        return None
 
     def assertEqualInLua(self, a, b):
         lua_type_a = lupa.lua_type(a)
@@ -2714,9 +2720,6 @@ class PythonArgumentsInLuaTest(SetupLuaRuntimeMixin, unittest.TestCase):
 
 
 class PythonArgumentsInLuaMethodsTest(PythonArgumentsInLuaTest):
-
-    def __init__(self, *args, **kwargs):
-        super(PythonArgumentsInLuaTest, self).__init__(*args, **kwargs)
 
     def get_args(self, *args, **kwargs):
         return args

--- a/lupa/tests/test.py
+++ b/lupa/tests/test.py
@@ -21,7 +21,7 @@ except NameError:
 
 unicode_type = type('abc'.decode('ASCII') if IS_PYTHON2 else 'abc')
 
-if sys.version_info[:2] == (2, 7):
+if IS_PYTHON2:
     unittest.TestCase.assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
 
 class SetupLuaRuntimeMixin(object):


### PR DESCRIPTION
* Add `python.args` function for building Python arguments (+tests)
* Add internal `unpack_lua_table` used by `lupa.unpacks_lua_table`, `lupa.unpacks_lua_table_method` and `python.args`
  * Throw `IndexError` if table being unpacked has "isolated" integer key (+tests)

Closes https://github.com/scoder/lupa/issues/176