### PR TITLE
Export limits for Lua integers

### DIFF
--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -91,7 +91,18 @@ include "lock.pxi"
 
 cdef int _LUA_VERSION = lua.read_lua_version(NULL)
 LUA_VERSION = (_LUA_VERSION // 100, _LUA_VERSION % 100)
-LUA_MININTEGER, LUA_MAXINTEGER = (lua.LUA_MININTEGER, lua.LUA_MAXINTEGER)
+
+cdef extern from *:
+    const int INT_MIN, INT_MAX
+    const long LONG_MIN, LONG_MAX
+    const long long PY_LLONG_MIN, PY_LLONG_MAX
+
+LUA_MININTEGER, LUA_MAXINTEGER = (
+    (lua.LUA_MININTEGER, lua.LUA_MAXINTEGER) if lua.LUA_VERSION_NUM >= 504 else
+    (PY_LLONG_MIN, PY_LLONG_MAX) if sizeof(lua.lua_Integer) >= sizeof(long long) else  # probably not going to be larger
+    (LONG_MIN, LONG_MAX) if sizeof(lua.lua_Integer) == sizeof(long) else
+    (INT_MIN, INT_MAX)  # probably not going to be smaller
+)
 
 
 class LuaError(Exception):

--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -37,8 +37,10 @@ cdef extern from *:
     #endif
     """
     ctypedef size_t uintptr_t
-    cdef Py_ssize_t PY_SSIZE_T_MAX
-    cdef long LONG_MIN, LONG_MAX
+    cdef const Py_ssize_t PY_SSIZE_T_MAX
+    cdef const int INT_MIN, INT_MAX
+    cdef const long LONG_MIN, LONG_MAX
+    cdef const long long PY_LLONG_MIN, PY_LLONG_MAX
 
 cdef object exc_info
 from sys import exc_info
@@ -91,17 +93,11 @@ include "lock.pxi"
 
 cdef int _LUA_VERSION = lua.read_lua_version(NULL)
 LUA_VERSION = (_LUA_VERSION // 100, _LUA_VERSION % 100)
-
-cdef extern from *:
-    const int INT_MIN, INT_MAX
-    const long LONG_MIN, LONG_MAX
-    const long long PY_LLONG_MIN, PY_LLONG_MAX
-
 LUA_MININTEGER, LUA_MAXINTEGER = (
-    (lua.LUA_MININTEGER, lua.LUA_MAXINTEGER) if lua.LUA_VERSION_NUM >= 504 else
-    (PY_LLONG_MIN, PY_LLONG_MAX) if sizeof(lua.lua_Integer) >= sizeof(long long) else  # probably not going to be larger
-    (LONG_MIN, LONG_MAX) if sizeof(lua.lua_Integer) == sizeof(long) else
-    (INT_MIN, INT_MAX)  # probably not going to be smaller
+    (lua.LUA_MININTEGER, lua.LUA_MAXINTEGER) if lua.LUA_VERSION_NUM >= 503 else
+    (<lua.lua_Integer>PY_LLONG_MIN, <lua.lua_Integer>PY_LLONG_MAX) if sizeof(lua.lua_Integer) >= sizeof(long long) else  # probably not going to be larger
+    (<lua.lua_Integer>LONG_MIN, <lua.lua_Integer>LONG_MAX) if sizeof(lua.lua_Integer) >= sizeof(long) else
+    (<lua.lua_Integer>INT_MIN, <lua.lua_Integer>INT_MAX)  # probably not going to be smaller
 )
 
 

--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -39,7 +39,7 @@ cdef extern from *:
     ctypedef size_t uintptr_t
     cdef const Py_ssize_t PY_SSIZE_T_MAX
     cdef const char CHAR_MIN, CHAR_MAX
-    cdef const short SHORT_MIN, SHORT_MAX
+    cdef const short SHRT_MIN, SHRT_MAX
     cdef const int INT_MIN, INT_MAX
     cdef const long LONG_MIN, LONG_MAX
     cdef const long long PY_LLONG_MIN, PY_LLONG_MAX
@@ -106,7 +106,7 @@ elif sizeof(lua.lua_Integer) >= sizeof(long):
 elif sizeof(lua.lua_Integer) >= sizeof(int):
     LUA_MININTEGER, LUA_MAXINTEGER = (INT_MIN, INT_MAX)
 elif sizeof(lua.lua_Integer) >= sizeof(short):
-    LUA_MININTEGER, LUA_MAXINTEGER = (SHORT_MIN, SHORT_MAX)
+    LUA_MININTEGER, LUA_MAXINTEGER = (SHRT_MIN, SHRT_MAX)
 else:  # probably not smaller
     LUA_MININTEGER, LUA_MAXINTEGER = (CHAR_MIN, CHAR_MAX)
 

--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -39,6 +39,7 @@ cdef extern from *:
     ctypedef size_t uintptr_t
     cdef const Py_ssize_t PY_SSIZE_T_MAX
     cdef const char CHAR_MIN, CHAR_MAX
+    cdef const short SHORT_MIN, SHORT_MAX
     cdef const int INT_MIN, INT_MAX
     cdef const long LONG_MIN, LONG_MAX
     cdef const long long PY_LLONG_MIN, PY_LLONG_MAX
@@ -96,7 +97,7 @@ cdef int _LUA_VERSION = lua.read_lua_version(NULL)
 LUA_VERSION = (_LUA_VERSION // 100, _LUA_VERSION % 100)
 
 
-if lua.LUA_VERSION_NUM >= 503:
+if lua.LUA_MAXINTEGER > 0:
     LUA_MININTEGER, LUA_MAXINTEGER = (lua.LUA_MININTEGER, lua.LUA_MAXINTEGER)
 elif sizeof(lua.lua_Integer) >= sizeof(long long):  # probably not larger
     LUA_MININTEGER, LUA_MAXINTEGER = (PY_LLONG_MIN, PY_LLONG_MAX)
@@ -104,6 +105,8 @@ elif sizeof(lua.lua_Integer) >= sizeof(long):
     LUA_MININTEGER, LUA_MAXINTEGER = (LONG_MIN, LONG_MAX)
 elif sizeof(lua.lua_Integer) >= sizeof(int):
     LUA_MININTEGER, LUA_MAXINTEGER = (INT_MIN, INT_MAX)
+elif sizeof(lua.lua_Integer) >= sizeof(short):
+    LUA_MININTEGER, LUA_MAXINTEGER = (SHORT_MIN, SHORT_MAX)
 else:  # probably not smaller
     LUA_MININTEGER, LUA_MAXINTEGER = (CHAR_MIN, CHAR_MAX)
 

--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -91,18 +91,7 @@ include "lock.pxi"
 
 cdef int _LUA_VERSION = lua.read_lua_version(NULL)
 LUA_VERSION = (_LUA_VERSION // 100, _LUA_VERSION % 100)
-
-cdef extern from *:
-    const int INT_MIN, INT_MAX
-    const long LONG_MIN, LONG_MAX
-    const long long PY_LLONG_MIN, PY_LLONG_MAX
-
-LUA_MININTEGER, LUA_MAXINTEGER = (
-    (lua.LUA_MININTEGER, lua.LUA_MAXINTEGER) if lua.LUA_VERSION_NUM >= 504 else
-    (PY_LLONG_MIN, PY_LLONG_MAX) if sizeof(lua.lua_Integer) >= sizeof(long long) else  # probably not going to be larger
-    (LONG_MIN, LONG_MAX) if sizeof(lua.lua_Integer) == sizeof(long) else
-    (INT_MIN, INT_MAX)  # probably not going to be smaller
-)
+LUA_MININTEGER, LUA_MAXINTEGER = (lua.LUA_MININTEGER, lua.LUA_MAXINTEGER)
 
 
 class LuaError(Exception):

--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -91,8 +91,18 @@ include "lock.pxi"
 
 cdef int _LUA_VERSION = lua.read_lua_version(NULL)
 LUA_VERSION = (_LUA_VERSION // 100, _LUA_VERSION % 100)
-LUA_MININTEGER = lua.LUA_MININTEGER
-LUA_MAXINTEGER = lua.LUA_MAXINTEGER
+
+cdef extern from *:
+    const int INT_MIN, INT_MAX
+    const long LONG_MIN, LONG_MAX
+    const long long PY_LLONG_MIN, PY_LLONG_MAX
+
+LUA_MININTEGER, LUA_MAXINTEGER = (
+    (lua.LUA_MININTEGER, lua.LUA_MAXINTEGER) if lua.LUA_VERSION_NUM >= 504 else
+    (PY_LLONG_MIN, PY_LLONG_MAX) if sizeof(lua.lua_Integer) >= sizeof(long long) else  # probably not going to be larger
+    (LONG_MIN, LONG_MAX) if sizeof(lua.lua_Integer) == sizeof(long) else
+    (INT_MIN, INT_MAX)  # probably not going to be smaller
+)
 
 
 class LuaError(Exception):

--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -53,7 +53,8 @@ cdef object wraps
 from functools import wraps
 
 
-__all__ = ['LUA_VERSION', 'LuaRuntime', 'LuaError', 'LuaSyntaxError',
+__all__ = ['LUA_VERSION', 'LUA_MAXINTEGER', 'LUA_MININTEGER',
+            'LuaRuntime', 'LuaError', 'LuaSyntaxError',
            'as_itemgetter', 'as_attrgetter', 'lua_type',
            'unpacks_lua_table', 'unpacks_lua_table_method']
 
@@ -90,6 +91,8 @@ include "lock.pxi"
 
 cdef int _LUA_VERSION = lua.read_lua_version(NULL)
 LUA_VERSION = (_LUA_VERSION // 100, _LUA_VERSION % 100)
+LUA_MININTEGER = lua.LUA_MININTEGER
+LUA_MAXINTEGER = lua.LUA_MAXINTEGER
 
 
 class LuaError(Exception):

--- a/lupa/lua.pxd
+++ b/lupa/lua.pxd
@@ -458,11 +458,24 @@ cdef extern from *:
 
 
 cdef extern from *:
-    # Limits for Lua integers (in Lua<5.4: PTRDIFF_MIN, PTRDIFF_MAX)
+    # Limits for Lua integers (in Lua<5.3: PTRDIFF_MIN, PTRDIFF_MAX)
     """
     #if LUA_VERSION_NUM < 503
-    #define LUA_MAXINTEGER 0
-    #define LUA_MININTEGER 0
+    #   if sizeof(lua_Integer) >= sizeof(long long)
+    #       define LUA_MAXINTEGER PY_LLONG_MAX
+    #       define LUA_MININTEGER PY_LLONG_MIN
+    #   elif sizeof(lua_Integer) >= sizeof(long)
+    #       define LUA_MAXINTEGER LONG_MAX
+    #       define LUA_MININTEGER LONG_MIN
+    #   elif sizeof(lua_Integer) >= sizeof(int)
+    #       define LUA_MAXINTEGER INT_MAX
+    #       define LUA_MININTEGER INT_MIN
+    #   elif sizeof(lua_Integer) >= sizeof(char)
+    #       define LUA_MAXINTEGER CHAR_MAX
+    #       define LUA_MININTEGER CHAR_MIN
+    #   else
+    #       error "lua_Integer can't be smaller than char"
+    #   endif
     #endif
     """
     lua_Integer LUA_MAXINTEGER

--- a/lupa/lua.pxd
+++ b/lupa/lua.pxd
@@ -457,14 +457,13 @@ cdef extern from *:
     int lua_isinteger(lua_State *L, int idx)
 
 
-cdef extern from "stdint.h":
-    # Limits for Lua integers
+cdef extern from *:
+    # Limits for Lua integers (in Lua<5.4: PTRDIFF_MIN, PTRDIFF_MAX)
     """
     #if LUA_VERSION_NUM < 503
-    #define LUA_MAXINTEGER PTRDIFF_MAX
-    #define LUA_MININTEGER PTRDIFF_MIN
+    #define LUA_MAXINTEGER 0
+    #define LUA_MININTEGER 0
     #endif
     """
     lua_Integer LUA_MAXINTEGER
     lua_Integer LUA_MININTEGER
-

--- a/lupa/lua.pxd
+++ b/lupa/lua.pxd
@@ -458,24 +458,11 @@ cdef extern from *:
 
 
 cdef extern from *:
-    # Limits for Lua integers (in Lua<5.3: PTRDIFF_MIN, PTRDIFF_MAX)
+    # Limits for Lua integers (in Lua<5.4: PTRDIFF_MIN, PTRDIFF_MAX)
     """
     #if LUA_VERSION_NUM < 503
-    #   if sizeof(lua_Integer) >= sizeof(long long)
-    #       define LUA_MAXINTEGER PY_LLONG_MAX
-    #       define LUA_MININTEGER PY_LLONG_MIN
-    #   elif sizeof(lua_Integer) >= sizeof(long)
-    #       define LUA_MAXINTEGER LONG_MAX
-    #       define LUA_MININTEGER LONG_MIN
-    #   elif sizeof(lua_Integer) >= sizeof(int)
-    #       define LUA_MAXINTEGER INT_MAX
-    #       define LUA_MININTEGER INT_MIN
-    #   elif sizeof(lua_Integer) >= sizeof(char)
-    #       define LUA_MAXINTEGER CHAR_MAX
-    #       define LUA_MININTEGER CHAR_MIN
-    #   else
-    #       error "lua_Integer can't be smaller than char"
-    #   endif
+    #define LUA_MAXINTEGER 0
+    #define LUA_MININTEGER 0
     #endif
     """
     lua_Integer LUA_MAXINTEGER

--- a/lupa/lua.pxd
+++ b/lupa/lua.pxd
@@ -455,3 +455,16 @@ cdef extern from *:
     """
     int read_lua_version(lua_State *L)
     int lua_isinteger(lua_State *L, int idx)
+
+
+cdef extern from "stdint.h":
+    # Limits for Lua integers
+    """
+    #if LUA_VERSION_NUM < 503
+    #define LUA_MAXINTEGER PTRDIFF_MAX
+    #define LUA_MININTEGER PTRDIFF_MIN
+    #endif
+    """
+    lua_Integer LUA_MAXINTEGER
+    lua_Integer LUA_MININTEGER
+

--- a/lupa/lua.pxd
+++ b/lupa/lua.pxd
@@ -458,7 +458,7 @@ cdef extern from *:
 
 
 cdef extern from *:
-    # Limits for Lua integers (in Lua<5.4: PTRDIFF_MIN, PTRDIFF_MAX)
+    # Limits for Lua integers (in Lua<5.3: PTRDIFF_MIN, PTRDIFF_MAX)
     """
     #if LUA_VERSION_NUM < 503
     #define LUA_MAXINTEGER 0

--- a/lupa/tests/test.py
+++ b/lupa/tests/test.py
@@ -2624,12 +2624,13 @@ class TestErrorStackTrace(unittest.TestCase):
 # tests for handling overflow
 
 class TestOverflowMixin(SetupLuaRuntimeMixin):
-    maxinteger = sys.maxint if IS_PYTHON2 else sys.maxsize  # maximum value for C Py_ssize_t
-    biginteger = (maxinteger + 1) << 1  # value too big to fit in C size_t
+    maxinteger = lupa.LUA_MAXINTEGER    # maximum value for Lua integer
+    mininteger = lupa.LUA_MININTEGER    # minimum value for Lua integer
+    biginteger = (maxinteger + 1) << 1  # value too big to fit in a Lua integer
     maxfloat = sys.float_info.max       # maximum value for Python float
     bigfloat = int(maxfloat) * 2        # value too big to fit in Python float
 
-    assert biginteger <= maxfloat
+    assert biginteger <= maxfloat, "%d can't be cast to float" % biginteger
 
     def setUp(self):
         super(TestOverflowMixin, self).setUp()
@@ -2646,7 +2647,7 @@ class TestOverflowMixin(SetupLuaRuntimeMixin):
         self.assertMathType(10, 'integer')
         self.assertMathType(-10, 'integer')
         self.assertMathType(self.maxinteger, 'integer')
-        self.assertMathType(-self.maxinteger, 'integer')
+        self.assertMathType(self.mininteger, 'integer')
         self.assertMathType(0.0, 'float')
         self.assertMathType(-0.0, 'float')
         self.assertMathType(10.0, 'float')
@@ -2683,7 +2684,7 @@ class TestOverflowWithFloatHandler(TestOverflowMixin, unittest.TestCase):
 class TestOverflowWithObjectHandler(TestOverflowMixin, unittest.TestCase):
     def test_overflow(self):
         self.lua.execute('python.set_overflow_handler(function(o) return o end)')
-        self.assertEqual(self.lua.eval('type')(int(self.maxfloat)), 'userdata')
+        self.assertEqual(self.lua.eval('type')(self.biginteger), 'userdata')
 
 
 class TestFloatOverflowHandlerInLua(TestOverflowMixin, unittest.TestCase):


### PR DESCRIPTION
* Add `lupa.LUA_MININTEGER` and `lupa.LUA_MAXINTEGER`
* Fix integer overflow tests for Windows x86