### PR TITLE
Safety fixes and refactoring

### DIFF
--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -485,7 +485,6 @@ cdef class LuaRuntime:
         with self.stack(4):                             # lib
             lua.lua_pushlstring(L, cname, len(cname))   # lib cname
             if not py_to_lua_custom(self, L, obj, 0):   # lib cname obj
-                lua.lua_pop(L, 1)
                 raise LuaError("failed to convert %s object" % pyname)
             lua.lua_pushlstring(L, pyname, len(pyname)) # lib cname obj pyname
             lua.lua_pushvalue(L, -2)                    # lib cname obj pyname obj
@@ -1260,7 +1259,7 @@ cdef py_object* unpack_userdata(lua_State *L, int n) nogil:
 cdef int py_function_result_to_lua(LuaRuntime runtime, lua_State *L, object o) except -1:
      if runtime._unpack_returned_tuples and isinstance(o, tuple):
          py_tuple_to_lua(runtime, L, <tuple>o)
-         return <int>len(<tuple>o)
+         return len(<tuple>o)
      check_lua_stack(L, 1)
      return py_to_lua(runtime, L, o)
 

--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -165,9 +165,11 @@ cdef class _LuaRuntimeStack:
     """Context handler for the Lua runtime stack"""
     cdef LuaRuntime _runtime
     cdef int _top
+    cdef int _extra
 
     def __enter__(self):
         lock_runtime(self._runtime)
+        check_lua_stack(self._runtime._state, self._extra)
         self._top = lua.lua_gettop(self._runtime._state)
 
     def __exit__(self, exc_type, exc_value, traceback):
@@ -311,9 +313,9 @@ cdef class LuaRuntime:
         Ensures 'extra' slots in the stack
         """
         cdef _LuaRuntimeStack ctx
-        check_lua_stack(self._state, extra)
         ctx = _LuaRuntimeStack.__new__(_LuaRuntimeStack)
         ctx._runtime = self
+        ctx._extra = extra
         return ctx
 
     @property


### PR DESCRIPTION
* Adds `LuaRuntime.stack` for context managing the Lua stack, which makes the code cleaner and safer
* Calls `check_lua_stack` where needed (avoids Lua stack overflow)
* Optimize py_to_lua, handling `True` and `False` separately because `<bint>` cast calls `Py_IsTrue` unnecessarily.
* Partial rewrite of `_LuaObject.__str__`, `_LuaTable._setitem`, `_LuaFunction.coroutine`
* Removed `lua_settop(L, 0)` from `_LuaObject.__call__`.
* Renamed `push_lua_arguments` to `py_tuple_to_lua` and made it safe against `py_to_lua` exceptions
* Renamed `unpack_lua_results` to `py_tuple_from_lua` and added `nargs` parameter instead of getting from Lua stack top