### PR TITLE
Great changes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -715,22 +715,6 @@ Python space:
       >>> list(lua_gen)
       []
 
-      >>> # an uninitialised coroutine:
-
-      >>> gen = co(4)
-      >>> list(enumerate(gen))
-      [(0, 0), (1, 1), (2, 0), (3, 1), (4, 0)]
-
-      >>> gen = co(2)
-      >>> list(enumerate(gen))
-      [(0, 0), (1, 1), (2, 0)]
-
-      >>> # a plain function:
-
-      >>> gen = f.coroutine(4)
-      >>> list(enumerate(gen))
-      [(0, 0), (1, 1), (2, 0), (3, 1), (4, 0)]
-
 
 Threading
 ---------

--- a/lupa/lua.pxd
+++ b/lupa/lua.pxd
@@ -456,11 +456,15 @@ cdef extern from * nogil:
     #else
     #error Lupa requires at least Lua 5.1 or LuaJIT 2.x
     #endif
+
+    #if LUA_VERSION_NUM < 502
+    #define lua_pushglobaltable(L)  lua_pushvalue(L, LUA_GLOBALSINDEX)
+    #endif
     """
     int read_lua_version(lua_State *L)
     int lua_isinteger(lua_State *L, int idx)
     lua_Integer lua_tointegerx (lua_State *L, int idx, int *isnum)
-
+    void lua_pushglobaltable (lua_State *L)
 
 cdef extern from *:
     # Limits for Lua integers (in Lua<5.3: PTRDIFF_MIN, PTRDIFF_MAX)

--- a/setup.py
+++ b/setup.py
@@ -322,7 +322,7 @@ ext_modules = [
     )]
 
 if cythonize is not None:
-    ext_modules = cythonize(ext_modules)
+    ext_modules = cythonize(ext_modules, gdb_debug=has_option('--gdb-debug'))
 
 
 def read_file(filename):


### PR DESCRIPTION
It's basically a diff between my fork and the original repo
```
Legend: +additions -removals *changes
+ stack context handler (locks runtime, checks extra slots in stack and restores stack top)
+ better panic function (prints the Python stack before Lua aborts the program)
+ proper error handling between Lua and Python
+ wraps Python exceptions + tracebacks in a _PyException object
+ converts Lua traceback to Python traceback
+ python.exec (lupa.LuaRuntime.execute counterpart)
+ 'register_exec' option, defaults to True
+ python.PYTHON_VERSION (lupa.LUA_VERSION counterpart)
+ python.pack (Lua values -> Python tuple, like table.pack)
+ python.unpack (Python tuple -> Lua values, like table.unpack)
+ python.is_object (for checking if Lua value is a wrapped Python object)
+ python.is_error (for checking if Lua value is a wrapped _PyException object)
+ adds assertions for catching Lua C API misuses (e.g. indexing non-tabular value)
+ caches Lua objects
+ add tests
+ add '--gdb-debug' option for compiling with gdb debug information
* made names in the registry more descriptive to avoid conflicts
* simplified library registration
* simplified _LuaObject getter/setter/delete methods
* use lua_pushglobaltable for Lua 5.2+
* made lock_runtime return 0 on error, instead of raising error
* simplified _LuaThread.__bool__ and resume_lua_thread
* overflow handler defaults to returning wrapped Python integer to Lua
* py_to_lua raises an error instead of returning 0
* py_to_lua_custom raises an error instead of returning 0
* calling Lua functions from Python doesn't need to set stack top to 0
* unpack_multiple_lua_results (now py_tuple_from_lua) works with top 'nargs' elements
* make python.args be usable only in the last position to respect Lua semantics
- _LuaCoroutineFunction (messes up Lua caching)
```