### PR TITLE
Safer handling of the Lua stack

### DIFF
--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -409,6 +409,7 @@ cdef class LuaRuntime:
         top = getstacktop(self, L, 5)
         try:
             # FIXME: how to check for failure?
+            lua.lua_newtable(L)
             for obj in args:
                 if isinstance(obj, dict):
                     for key, value in obj.iteritems():
@@ -1335,8 +1336,8 @@ cdef int py_to_lua_handle_overflow(LuaRuntime runtime, lua_State *L, object o) e
         Returns 0 if cannot convert Python object to Lua (handler not registered or failed)
         Returns 1 if the Python object was converted successfully and pushed onto the stack
     """
-    top = lua.lua_gettop(L)
     check_lua_stack(L, 2)
+    top = lua.lua_gettop(L)
     try:
         lua.lua_pushlstring(L, LUPAOFH, len(LUPAOFH))
         lua.lua_rawget(L, lua.LUA_REGISTRYINDEX)
@@ -1999,6 +2000,7 @@ cdef int py_push_iterator(LuaRuntime runtime, lua_State* L, iterator, int type_f
     """Pushes iterator function, invariant state variable and control variable
     Preconditions:
         3 extra slots in the Lua stack
+        LuaRuntime is locked
     Postconditions:
         Pushes py_iter_next, iterator and the control variable
         Returns the number of pushed values

--- a/lupa/lua.pxd
+++ b/lupa/lua.pxd
@@ -93,7 +93,7 @@ cdef extern from "lua.h" nogil:
     int             lua_iscfunction (lua_State *L, int idx)
     int             lua_isuserdata (lua_State *L, int idx)
     int             lua_type (lua_State *L, int idx)
-    char           *lua_typename (lua_State *L, int tp)
+    const char     *lua_typename (lua_State *L, int tp)
 
     int             lua_equal (lua_State *L, int idx1, int idx2)
     int             lua_rawequal (lua_State *L, int idx1, int idx2)

--- a/lupa/lua.pxd
+++ b/lupa/lua.pxd
@@ -456,11 +456,15 @@ cdef extern from * nogil:
     #else
     #error Lupa requires at least Lua 5.1 or LuaJIT 2.x
     #endif
+
+    #if LUA_VERSION_NUM < 502
+    #define lua_pushglobaltable(L)  lua_pushvalue(L, LUA_GLOBALSINDEX)
+    #endif
     """
     int read_lua_version(lua_State *L)
     int lua_isinteger(lua_State *L, int idx)
     lua_Integer lua_tointegerx (lua_State *L, int idx, int *isnum)
-
+    void lua_pushglobaltable (lua_State *L)
 
 cdef extern from *:
     # Limits for Lua integers (in Lua<5.3: PTRDIFF_MIN, PTRDIFF_MAX)

--- a/lupa/lua.pxd
+++ b/lupa/lua.pxd
@@ -278,6 +278,11 @@ cdef extern from "lauxlib.h" nogil:
     enum:
         LUA_ERRFILE #     (LUA_ERRERR+1)
 
+    # pre-defined references
+    enum:
+        LUA_NOREF   # -2
+        LUA_REFNIL  # -1
+
     ctypedef struct luaL_Reg:
         char *name
         lua_CFunction func


### PR DESCRIPTION
Some places don't lock the LuaRuntime before fiddling with the Lua stack, and many places don't ensure extra slots either.
This PR also involves other changes:
* Add preconditions and postconditions to important functions/methods
* Change behaviour `_LuaObject.__str__`
  * If `__tostring` doesn't exist, use `_LuaObject.__repr__`
  * If `__tostring` returns non-string value, raise a `TypeError`
  * If `__tostring` raises an error, raise a `LuaError`
* `lua_pushglobaltable` instead of pushing `_G`, which may not point to the global table.
* Make `lock_runtime` return boolean and not raise error directly
* Use `LUA_NOREF` and `LUA_REFNIL` constants for effective handling of Lua references
* Add important assertions (checks if `LuaRuntime._state` is not `NULL`, and if `_LuaObject._runtime` is `None`, etc...)