### PR TITLE
Ship multiple Lua versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       run: sudo apt-get install lib${{ matrix.lua-version }}-dev
 
     - name: Build wheel
-      run: python -m pip install -r requirements.txt && python setup.py sdist build_ext -j5 bdist_wheel
+      run: python -m pip install -r requirements.txt && python setup.py sdist ${{ contains(matrix.python-version, '3.') && 'build_ext -j5' || '' }} bdist_wheel
       env:
         SETUP_OPTIONS: ${{ !contains(matrix.lua-version, 'luajit') && (contains(matrix.lua-version, 'bundle') && '--use-bundle' || '--no-luajit') || '' }}
         CFLAGS: ${{ env.CFLAGS }} ${{ env.CFLAGS_LTO }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os: [windows-2019, ubuntu-20.04, macos-11]
         python-version: ["2.7", "3.10", "3.9", "3.8", "3.7", "3.6", "pypy-2.7", "pypy-3.7", "pypy-3.8"]
-        lua-version: ["bundle", "lua5.4", "lua5.3", "lua5.2", "luajit-5.1"]
+        lua-version: ["bundle", "lua5.3", "lua5.2", "luajit-5.1"]
 
         exclude:
           - os: windows-2019

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       run: sudo apt-get install lib${{ matrix.lua-version }}-dev
 
     - name: Build wheel
-      run: python -m pip install -r requirements.txt && python setup.py sdist bdist_wheel
+      run: python -m pip install -r requirements.txt && python setup.py sdist build_ext -j5 bdist_wheel
       env:
         SETUP_OPTIONS: ${{ !contains(matrix.lua-version, 'luajit') && (contains(matrix.lua-version, 'bundle') && '--use-bundle' || '--no-luajit') || '' }}
         CFLAGS: ${{ env.CFLAGS }} ${{ env.CFLAGS_LTO }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: true
+        submodules: recursive
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
       fail-fast: false
 
       matrix:
-        os: [windows-2019, ubuntu-18.04, macos-10.15]
-        python-version: ["2.7", "3.10", "3.9", "3.8", "3.7", "3.6", "3.5", "pypy-2.7", "pypy-3.7", "pypy-3.8"]
-        lua-version: ["bundle", "lua5.2", "lua5.3", "luajit-5.1"]
+        os: [windows-2019, ubuntu-20.04, macos-11]
+        python-version: ["2.7", "3.10", "3.9", "3.8", "3.7", "3.6", "pypy-2.7", "pypy-3.7", "pypy-3.8"]
+        lua-version: ["bundle", "lua5.4", "lua5.3", "lua5.2", "luajit-5.1"]
 
         exclude:
           - os: windows-2019
@@ -24,14 +24,18 @@ jobs:
           - os: windows-2019
             lua-version: lua5.3
           - os: windows-2019
+            lua-version: lua5.4
+          - os: windows-2019
             lua-version: luajit-5.1
-          - os: macos-10.15
+          - os: macos-11
             python-version: 2.7
-          - os: macos-10.15
+          - os: macos-11
             lua-version: lua5.2
-          - os: macos-10.15
+          - os: macos-11
             lua-version: lua5.3
-          - os: macos-10.15
+          - os: macos-11
+            lua-version: lua5.4
+          - os: macos-11
             lua-version: luajit-5.1
 
     runs-on: ${{ matrix.os }}
@@ -39,7 +43,7 @@ jobs:
     env:
       CFLAGS_LTO: ${{ contains(matrix.lua-version, 'bundle')  && (contains(matrix.os, 'windows') && '/LTCG' || '-flto') || '' }}
       CFLAGS: ${{ contains(matrix.os, 'windows') && '/O2' || '-O2 -fPIC' }} -g
-      MACOSX_DEPLOYMENT_TARGET: "10.14"
+      MACOSX_DEPLOYMENT_TARGET: "10.15"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        submodules: recursive
+
+    - name: Check out recursively
+      run: git submodule update --init --recursive
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
     env:
       CFLAGS_LTO: ${{ contains(matrix.lua-version, 'bundle')  && (contains(matrix.os, 'windows') && '/LTCG' || '-flto') || '' }}
       CFLAGS: ${{ contains(matrix.os, 'windows') && '/O2' || '-O2 -fPIC' }} -g
+      MACOSX_DEPLOYMENT_TARGET: "10.14"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
 
     env:
       CFLAGS_LTO: ${{ contains(matrix.lua-version, 'bundle')  && (contains(matrix.os, 'windows') && '/LTCG' || '-flto') || '' }}
+      CFLAGS: ${{ contains(matrix.os, 'windows') && '/O2' || '-O2 -fPIC' }} -g
 
     steps:
     - uses: actions/checkout@v2
@@ -61,7 +62,7 @@ jobs:
       run: python -m pip install -r requirements.txt && python setup.py sdist bdist_wheel
       env:
         SETUP_OPTIONS: ${{ !contains(matrix.lua-version, 'luajit') && (contains(matrix.lua-version, 'bundle') && '--use-bundle' || '--no-luajit') || '' }}
-        CFLAGS: ${{ env.CFLAGS_LTO }} -g
+        CFLAGS: ${{ env.CFLAGS }} ${{ env.CFLAGS_LTO }}
         LDFLAGS: ${{ env.CFLAGS_LTO }}
 
     - name: Run tests
@@ -69,7 +70,7 @@ jobs:
       continue-on-error: ${{ contains(matrix.python-version, 'pypy') }}
       env:
         SETUP_OPTIONS: ${{ !contains(matrix.lua-version, 'luajit') && (contains(matrix.lua-version, 'bundle') && '--use-bundle' || '--no-luajit') || '' }}
-        CFLAGS: ${{ env.CFLAGS_LTO }} -g
+        CFLAGS: ${{ env.CFLAGS }} ${{ env.CFLAGS_LTO }}
         LDFLAGS: ${{ env.CFLAGS_LTO }}
 
     - name: Upload wheels

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
-    - name: Check out recursively
-      run: git submodule update --init --recursive
+      with:
+        submodules: true
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -10,9 +10,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
-    - name: Check out recursively
-      run: git submodule update --init --recursive
+      with:
+        submodules: true
 
     - name: Set up Python
       uses: actions/setup-python@v1
@@ -76,9 +75,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
-    - name: Check out recursively
-      run: git submodule update --init --recursive
+      with:
+        submodules: true
 
     - name: Set up Python
       uses: actions/setup-python@v2
@@ -129,9 +127,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
-    - name: Check out recursively
-      run: git submodule update --init --recursive
+      with:
+        submodules: true
 
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -10,8 +10,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        submodules: recursive
+
+    - name: Check out recursively
+      run: git submodule update --init --recursive
 
     - name: Set up Python
       uses: actions/setup-python@v1
@@ -75,8 +76,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        submodules: recursive
+
+    - name: Check out recursively
+      run: git submodule update --init --recursive
 
     - name: Set up Python
       uses: actions/setup-python@v2
@@ -127,8 +129,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        submodules: recursive
+
+    - name: Check out recursively
+      run: git submodule update --init --recursive
 
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -46,32 +46,42 @@ jobs:
 
       matrix:
         image:
-          - manylinux1_x86_64
-          - manylinux1_i686
-          #- manylinux2010_x86_64
-          #- manylinux2010_i686
-          - manylinux_2_24_x86_64
-          - manylinux_2_24_i686
-          - manylinux_2_24_aarch64
+          - manylinux2014_x86_64
+          - manylinux2014_i686
+          - manylinux_2_28_x86_64
+          - manylinux_2_28_i686
+          - manylinux_2_28_aarch64
           - musllinux_1_1_x86_64
+          - musllinux_1_1_aarch64
           #- manylinux_2_24_ppc64le
           #- manylinux_2_24_ppc64le
           #- manylinux_2_24_s390x
         pyversion: ["*"]
 
         exclude:
-          - image: manylinux_2_24_aarch64
+          - image: manylinux_2_28_aarch64
+            pyversion: "*"
+          - image: musllinux_1_1_aarch64
             pyversion: "*"
         include:
           - image: manylinux2014_aarch64
             pyversion: "cp36*"
-          - image: manylinux_2_24_aarch64
+          - image: manylinux_2_28_aarch64
             pyversion: "cp37*"
-          - image: manylinux_2_24_aarch64
+          - image: manylinux_2_28_aarch64
             pyversion: "cp38*"
-          - image: manylinux_2_24_aarch64
+          - image: manylinux_2_28_aarch64
             pyversion: "cp39*"
-          - image: manylinux_2_24_aarch64
+          - image: manylinux_2_28_aarch64
+            pyversion: "cp310*"
+
+          - image: musllinux_1_1_aarch64
+            pyversion: "cp37*"
+          - image: musllinux_1_1_aarch64
+            pyversion: "cp38*"
+          - image: musllinux_1_1_aarch64
+            pyversion: "cp39*"
+          - image: musllinux_1_1_aarch64
             pyversion: "cp310*"
 
     steps:
@@ -111,21 +121,19 @@ jobs:
       fail-fast: false
 
       matrix:
-        os: [macos-10.15, windows-latest]
-        #os: [macos-10.15, windows-latest, macOS-M1]
-        #os: [macos-10.15, macOS-M1]
-        #os: [macos-10.15]
-        python_version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "pypy-3.7-v7.3.3", "pypy-3.8-v7.3.7"]
+        os: [macos-11, windows-latest]
+        #os: [macos-11, windows-latest, macOS-M1]
+        #os: [macos-11, macOS-M1]
+        #os: [macos-11]
+        python_version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "pypy-3.7-v7.3.3", "pypy-3.8-v7.3.7"]
 
         exclude:
           # outdated compilers and probably not worth supporting anymore
           - os: windows-latest
             python_version: 2.7
-          - os: windows-latest
-            python_version: 3.5
 
     runs-on: ${{ matrix.os }}
-    env: { MACOSX_DEPLOYMENT_TARGET: 10.14 }
+    env: { MACOSX_DEPLOYMENT_TARGET: 10.15 }
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: true
+        submodules: recursive
 
     - name: Set up Python
       uses: actions/setup-python@v1
@@ -76,7 +76,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: true
+        submodules: recursive
 
     - name: Set up Python
       uses: actions/setup-python@v2
@@ -128,7 +128,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: true
+        submodules: recursive
 
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ MANIFEST
 *.patch
 wheel*/
 lupa/version.py
-lupa/lupa_lua*.pyx
+lupa/lua*.pyx
 
 # Vim swapfiles
 *.swp

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ MANIFEST
 *.patch
 wheel*/
 lupa/version.py
+lupa/lupa_lua*.pyx
 
 # Vim swapfiles
 *.swp

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,15 @@
-[submodule "third-party/lua53"]
-	path = third-party/lua53
-	url = https://github.com/lua/lua.git
 [submodule "third-party/lua54"]
 	path = third-party/lua54
 	url = https://github.com/lua/lua.git
-[submodule "third-party/luajit20"]
-	path = third-party/luajit20
-	url = https://luajit.org/git/luajit.git
+[submodule "third-party/lua53"]
+	path = third-party/lua53
+	url = https://github.com/lua/lua.git
+[submodule "third-party/lua52"]
+	path = third-party/lua52
+	url = https://github.com/lua/lua.git
 [submodule "third-party/luajit21"]
 	path = third-party/luajit21
+	url = https://luajit.org/git/luajit.git
+[submodule "third-party/luajit20"]
+	path = third-party/luajit20
 	url = https://luajit.org/git/luajit.git

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ test: local
 
 clean:
 	rm -fr build lupa/_lupa*.so lupa/lupa_*.pyx lupa/*.c
+	@for dir in third-party/*/; do $(MAKE) -C $${dir} clean; done
 
 realclean: clean
 	rm -fr lupa/_lupa.c

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test: local
 	PYTHONPATH=. $(PYTHON) -m lupa.tests.test
 
 clean:
-	rm -fr build lupa/_lupa.so
+	rm -fr build lupa/_lupa*.so lupa/lupa_*.pyx lupa/*.c
 
 realclean: clean
 	rm -fr lupa/_lupa.c

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test: local
 	PYTHONPATH=. $(PYTHON) -m lupa.tests.test
 
 clean:
-	rm -fr build lupa/_lupa*.so lupa/lupa_*.pyx lupa/*.c
+	rm -fr build lupa/_lupa*.so lupa/lua*.pyx lupa/*.c
 	@for dir in third-party/*/; do $(MAKE) -C $${dir} clean; done
 
 realclean: clean

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ MANYLINUX_IMAGES= \
 	manylinux_2_24_aarch64 \
 	manylinux_2_24_ppc64le \
 	manylinux_2_24_s390x \
-	musllinux_1_1_x86_64
+	musllinux_1_1_x86_64 \
+	musllinux_1_1_aarch64
 
 .PHONY: all local sdist test clean realclean
 

--- a/README.rst
+++ b/README.rst
@@ -90,19 +90,19 @@ a specific one via import:
 .. code:: python
 
     try:
-        import lupa.lupa_luajit20 as lupa
+        import lupa.luajit20 as lupa
     except ImportError:
         try:
-            import lupa.lupa_lua54 as lupa
+            import lupa.lua54 as lupa
         except ImportError:
             try:
-                import lupa.lupa_lua53 as lupa
+                import lupa.lua53 as lupa
             except ImportError:
                 import lupa
 
     print(f"Using {lupa.LuaRuntime().lua_implementation} (compiled with {lupa.LUA_VERSION})")
 
-Note that LuaJIT 2.1 may also be included (as ``lupa_luajit21``) but is currently in Alpha state.
+Note that LuaJIT 2.1 may also be included (as ``luajit21``) but is currently in Alpha state.
 
 
 Examples

--- a/README.rst
+++ b/README.rst
@@ -37,8 +37,8 @@ Major features
 
 * tested with Python 2.7/3.5 and later
 
-* written for LuaJIT2 (tested with LuaJIT 2.0.2), but also works
-  with the normal Lua interpreter (5.1 and later)
+* ships with Lua 5.3 and 5.4 (works with Lua 5.1 and later)
+  as well as LuaJIT 2.0 and 2.1 on systems that support it.
 
 * easy to hack on and extend as it is written in Cython, not C
 
@@ -78,6 +78,31 @@ Lupa is a very fast and thin wrapper around Lua or LuaJIT.  It makes it
 easy to write dynamic Lua code that accompanies dynamic Python code by
 switching between the two languages at runtime, based on the tradeoff
 between simplicity and speed.
+
+
+Which Lua version?
+------------------
+
+The binary wheels include different Lua versions as well as LuaJIT, if supported.
+By default, ``import lupa`` uses the latest Lua version, but you can choose
+a specific one via import:
+
+.. code:: python
+
+    try:
+        import lupa.lupa_luajit20 as lupa
+    except ImportError:
+        try:
+            import lupa.lupa_lua54 as lupa
+        except ImportError:
+            try:
+                import lupa.lupa_lua53 as lupa
+            except ImportError:
+                import lupa
+
+    print(f"Using {lupa.LuaRuntime().lua_implementation} (compiled with {lupa.LUA_VERSION})")
+
+Note that LuaJIT 2.1 may also be included (as ``lupa_luajit21``) but is currently in Alpha state.
 
 
 Examples

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,10 +3,11 @@ image: Visual Studio 2019
 
 environment:
   matrix:
-  - python: 27
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
-  - python: 27-x64
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+# Disable Py27 builds since they run into certificate issues when retrieving the LuaJIT git submodule.
+#  - python: 27
+#    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+#  - python: 27-x64
+#    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
   - python: 310
   - python: 310-x64
   - python: 39

--- a/lupa/__init__.py
+++ b/lupa/__init__.py
@@ -27,9 +27,35 @@ except:
 
 del _try_import_with_global_library_symbols
 
-# the following is all that should stay in the namespace:
 
-from lupa._lupa import *
+# Find the implementation with the latest Lua version available.
+
+def _import_newest_lib():
+    import os.path
+    import re
+
+    package_dir = os.path.dirname(__file__)
+    modules = [
+        match.groups() for match in (
+            re.match(r"(lupa_(lua[a-z]*)([0-9]*))\..*", filename)
+            for filename in os.listdir(package_dir)
+        )
+        if match
+    ]
+    if not modules:
+        raise RuntimeError("Failed to import Lupa binary module.")
+    # prefer Lua over LuaJIT and high versions over low versions.
+    module_name = max(modules, key=lambda m: (m[1] == 'lua', tuple(map(int, m[2] or '0'))))
+    module = __import__(module_name[0], level=1, fromlist="*", globals=globals())
+    # the following is all that should stay in the namespace:
+    globals().update(
+        (name, getattr(module, name))
+        for name in module.__all__
+    )
+
+
+_import_newest_lib()
+del _import_newest_lib
 
 try:
     from lupa.version import __version__

--- a/lupa/__init__.py
+++ b/lupa/__init__.py
@@ -29,8 +29,14 @@ del _try_import_with_global_library_symbols
 
 
 # Find the implementation with the latest Lua version available.
+_newest_lib = None
+
 
 def _import_newest_lib():
+    global _newest_lib
+    if _newest_lib is not None:
+        return _newest_lib
+
     import os.path
     import re
 
@@ -46,16 +52,29 @@ def _import_newest_lib():
         raise RuntimeError("Failed to import Lupa binary module.")
     # prefer Lua over LuaJIT and high versions over low versions.
     module_name = max(modules, key=lambda m: (m[1] == 'lua', tuple(map(int, m[2] or '0'))))
-    module = __import__(module_name[0], level=1, fromlist="*", globals=globals())
-    # the following is all that should stay in the namespace:
+    _newest_lib = __import__(module_name[0], level=1, fromlist="*", globals=globals())
+
+    return _newest_lib
+
+
+def __getattr__(name):
+    """
+    Get a name from the latest available Lua (or LuaJIT) module.
+    Imports the module as needed.
+    """
+    lua = _newest_lib if _newest_lib is not None else _import_newest_lib()
+    return getattr(lua, name)
+
+
+import sys
+if sys.version_info < (3, 7):
+    # Module level "__getattr__" requires Py3.7 or later => import latest Lua now
+    _import_newest_lib()
     globals().update(
-        (name, getattr(module, name))
-        for name in module.__all__
+        (name, getattr(_newest_lib, name))
+        for name in _newest_lib.__all__
     )
-
-
-_import_newest_lib()
-del _import_newest_lib
+del sys
 
 try:
     from lupa.version import __version__

--- a/lupa/__init__.py
+++ b/lupa/__init__.py
@@ -43,7 +43,7 @@ def _import_newest_lib():
     package_dir = os.path.dirname(__file__)
     modules = [
         match.groups() for match in (
-            re.match(r"(lupa_(lua[a-z]*)([0-9]*))\..*", filename)
+            re.match(r"((lua[a-z]*)([0-9]*))\..*", filename)
             for filename in os.listdir(package_dir)
         )
         if match

--- a/lupa/tests/__init__.py
+++ b/lupa/tests/__init__.py
@@ -20,7 +20,7 @@ def find_lua_modules():
     modules = [lupa]
     imported = set()
     for filename in os.listdir(os.path.dirname(os.path.dirname(__file__))):
-        if not filename.startswith('lupa_lua'):
+        if not filename.startswith('lua'):
             continue
         module_name = "lupa." + filename.partition('.')[0]
         if module_name in imported:

--- a/lupa/tests/__init__.py
+++ b/lupa/tests/__init__.py
@@ -18,7 +18,7 @@ def suite():
             tests.append('lupa.tests.'  + filename[:-3])
 
     suite = unittest.defaultTestLoader.loadTestsFromNames(tests)
-    suite.addTest(doctest.DocTestSuite(lupa._lupa))
+    suite.addTest(doctest.DocTestSuite(lupa))
 
     # Long version of
     # suite.addTest(doctest.DocFileSuite('../../README.rst'))

--- a/lupa/tests/__init__.py
+++ b/lupa/tests/__init__.py
@@ -9,6 +9,68 @@ import sys
 import lupa
 
 
+class LupaTestCase(unittest.TestCase):
+    """
+    Subclasses can use 'self.lupa' to get the test module, which build_suite_for_module() below will vary.
+    """
+    lupa = lupa
+
+
+def find_lua_modules():
+    modules = [lupa]
+    imported = set()
+    for filename in os.listdir(os.path.dirname(os.path.dirname(__file__))):
+        if not filename.startswith('lupa_lua'):
+            continue
+        module_name = "lupa." + filename.partition('.')[0]
+        if module_name in imported:
+            continue
+        try:
+            module = __import__(module_name, fromlist='*', level=0)
+        except ImportError:
+            pass
+        else:
+            imported.add(module_name)
+            modules.append(module)
+
+    return modules
+
+
+def build_suite_for_modules(loader, test_module_globals):
+    suite = unittest.TestSuite()
+    all_lua_modules = find_lua_modules()
+
+    for module in all_lua_modules[1:]:
+        suite.addTests(doctest.DocTestSuite(module))
+
+    def add_tests(cls):
+        tests = loader.loadTestsFromTestCase(cls)
+        suite.addTests(tests)
+
+    for name, test_class in test_module_globals.items():
+        if (not isinstance(test_class, type) or
+                not name.startswith('Test') or
+                not issubclass(test_class, unittest.TestCase)):
+            continue
+
+        if issubclass(test_class, LupaTestCase):
+            prefix = test_class.__name__ + "_"
+            qprefix = getattr(test_class, '__qualname__', test_class.__name__) + "_"
+
+            for module in all_lua_modules:
+                class TestClass(test_class):
+                    lupa = module
+
+                module_name = module.__name__.rpartition('.')[2]
+                TestClass.__name__ = prefix + module_name
+                TestClass.__qualname__ = qprefix + module_name
+                add_tests(TestClass)
+        else:
+            add_tests(test_class)
+
+    return suite
+
+
 def suite():
     test_dir = os.path.abspath(os.path.dirname(__file__))
 
@@ -18,7 +80,6 @@ def suite():
             tests.append('lupa.tests.'  + filename[:-3])
 
     suite = unittest.defaultTestLoader.loadTestsFromNames(tests)
-    suite.addTest(doctest.DocTestSuite(lupa))
 
     # Long version of
     # suite.addTest(doctest.DocFileSuite('../../README.rst'))

--- a/lupa/tests/test.py
+++ b/lupa/tests/test.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import, print_function
 
+import os.path
 import threading
 import operator
 import unittest
@@ -2385,9 +2386,19 @@ def _wait():
 class TestFastRLock(unittest.TestCase):
     """Copied from CPython's test.lock_tests module
     """
+    FastRLock = None
+
     def setUp(self):
-        from lupa._lupa import FastRLock
-        self.locktype = FastRLock
+        for filename in os.listdir(os.path.dirname(os.path.dirname(__file__))):
+            if filename.startswith('lupa_lua'):
+                try:
+                    module_name = "lupa." + filename.partition('.')[0]
+                    self.FastRLock = __import__(module_name, fromlist='FastRLock', level=0).FastRLock
+                except ImportError:
+                    pass
+        if self.FastRLock is None:
+            self.skipTest("No FastRLock implementation found")
+        self.locktype = self.FastRLock
 
     def tearDown(self):
         gc.collect()

--- a/lupa/tests/test.py
+++ b/lupa/tests/test.py
@@ -2,15 +2,17 @@
 
 from __future__ import absolute_import, print_function
 
-import os.path
-import threading
-import operator
-import unittest
-import time
-import sys
 import gc
+import operator
+import os.path
+import sys
+import threading
+import time
+import unittest
 
 import lupa
+import lupa.tests
+from lupa.tests import LupaTestCase
 
 IS_PYTHON2 = sys.version_info[0] < 3
 
@@ -25,18 +27,19 @@ unicode_type = type('abc'.decode('ASCII') if IS_PYTHON2 else 'abc')
 if IS_PYTHON2:
     unittest.TestCase.assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
 
+
 class SetupLuaRuntimeMixin(object):
     lua_runtime_kwargs = {}
 
     def setUp(self):
-        self.lua = lupa.LuaRuntime(**self.lua_runtime_kwargs)
+        self.lua = self.lupa.LuaRuntime(**self.lua_runtime_kwargs)
 
     def tearDown(self):
         self.lua = None
         gc.collect()
 
 
-class TestLuaRuntimeRefcounting(unittest.TestCase):
+class TestLuaRuntimeRefcounting(LupaTestCase):
     def _run_gc_test(self, run_test):
         gc.collect()
         old_count = len(gc.get_objects())
@@ -50,7 +53,7 @@ class TestLuaRuntimeRefcounting(unittest.TestCase):
 
     def test_runtime_cleanup(self):
         def run_test():
-            lua = lupa.LuaRuntime()
+            lua = self.lupa.LuaRuntime()
             lua_table = lua.eval('{1,2,3,4}')
             del lua
             self.assertEqual(1, lua_table[1])
@@ -62,7 +65,7 @@ class TestLuaRuntimeRefcounting(unittest.TestCase):
             def use_runtime():
                 return lua.eval('1+1')
 
-            lua = lupa.LuaRuntime()
+            lua = self.lupa.LuaRuntime()
             lua.globals()['use_runtime'] = use_runtime
             self.assertEqual(2, lua.eval('use_runtime()'))
 
@@ -74,20 +77,20 @@ class TestLuaRuntimeRefcounting(unittest.TestCase):
                 lua.eval('1+1')  # create ref-cycle with runtime
                 return 23
 
-            lua = lupa.LuaRuntime(attribute_handlers=(get_attr, None))
+            lua = self.lupa.LuaRuntime(attribute_handlers=(get_attr, None))
             assert lua.eval('python.eval.huhu') == 23
 
         self._run_gc_test(make_refcycle)
 
 
-class TestLuaRuntime(SetupLuaRuntimeMixin, unittest.TestCase):
+class TestLuaRuntime(SetupLuaRuntimeMixin, LupaTestCase):
     def test_lua_version(self):
         version = self.lua.lua_version
         self.assertEqual(tuple, type(version))
         self.assertEqual(5, version[0])  # let's assume that Lua 6 will require code/test changes
         self.assertTrue(version[1] >= 1)
         self.assertTrue(version[1] < 10)  # arbitrary boundary
-        self.assertEqual(version, lupa.LUA_VERSION)  # no distinction currently
+        self.assertEqual(version, self.lupa.LUA_VERSION)  # no distinction currently
 
     def test_lua_implementation(self):
         lua_implementation = self.lua.lua_implementation
@@ -107,20 +110,20 @@ class TestLuaRuntime(SetupLuaRuntimeMixin, unittest.TestCase):
         self.assertEqual((1, 2, 3), self.lua.eval('...', 1, 2, 3))
 
     def test_eval_error(self):
-        self.assertRaises(lupa.LuaError, self.lua.eval, '<INVALIDCODE>')
+        self.assertRaises(self.lupa.LuaError, self.lua.eval, '<INVALIDCODE>')
 
     def test_eval_error_cleanup(self):
         self.assertEqual(2, self.lua.eval('1+1'))
-        self.assertRaises(lupa.LuaError, self.lua.eval, '<INVALIDCODE>')
+        self.assertRaises(self.lupa.LuaError, self.lua.eval, '<INVALIDCODE>')
         self.assertEqual(2, self.lua.eval('1+1'))
-        self.assertRaises(lupa.LuaError, self.lua.eval, '<INVALIDCODE>')
+        self.assertRaises(self.lupa.LuaError, self.lua.eval, '<INVALIDCODE>')
         self.assertEqual(2, self.lua.eval('1+1'))
         self.assertEqual(2, self.lua.eval('1+1'))
 
     def test_eval_error_message_decoding(self):
         try:
             self.lua.eval('require "UNKNOWNöMODULEäNAME"')
-        except lupa.LuaError:
+        except self.lupa.LuaError:
             error = ('%s'.decode('ASCII') if IS_PYTHON2 else '%s') % sys.exc_info()[1]
         else:
             self.fail('expected error not raised')
@@ -223,7 +226,7 @@ class TestLuaRuntime(SetupLuaRuntimeMixin, unittest.TestCase):
         self.assertEqual(builtins, function())
 
     def test_pybuiltins_disabled(self):
-        lua = lupa.LuaRuntime(register_builtins=False)
+        lua = self.lupa.LuaRuntime(register_builtins=False)
         self.assertEqual(True, lua.eval('python.builtins == nil'))
 
     def test_call_none(self):
@@ -259,7 +262,7 @@ class TestLuaRuntime(SetupLuaRuntimeMixin, unittest.TestCase):
         self.assertEqual(2, self.lua.eval('python.eval("1+1")'))
 
     def test_python_eval_disabled(self):
-        lua = lupa.LuaRuntime(register_eval=False)
+        lua = self.lupa.LuaRuntime(register_eval=False)
         self.assertEqual(True, lua.eval('python.eval == nil'))
 
     def test_len_table_array(self):
@@ -800,7 +803,7 @@ class TestLuaRuntime(SetupLuaRuntimeMixin, unittest.TestCase):
             end
         ''')
         self.assertRaises(
-            lupa.LuaError,
+            self.lupa.LuaError,
             function,
             lambda: 5/0,
         )
@@ -812,7 +815,7 @@ class TestLuaRuntime(SetupLuaRuntimeMixin, unittest.TestCase):
                     return name + '1'
             raise AttributeError('denied')
 
-        lua = lupa.LuaRuntime(attribute_filter=attr_filter)
+        lua = self.lupa.LuaRuntime(attribute_filter=attr_filter)
         function = lua.eval('function(obj) return obj.__name__ end')
         class X(object):
             a = 0
@@ -848,22 +851,22 @@ class TestLuaRuntime(SetupLuaRuntimeMixin, unittest.TestCase):
 
     def test_lua_type(self):
         x = self.lua.eval('{}')
-        self.assertEqual('table', lupa.lua_type(x))
+        self.assertEqual('table', self.lupa.lua_type(x))
 
         x = self.lua.eval('function() return 1 end')
-        self.assertEqual('function', lupa.lua_type(x))
+        self.assertEqual('function', self.lupa.lua_type(x))
 
         x = self.lua.eval('function() coroutine.yield(1) end')
-        self.assertEqual('function', lupa.lua_type(x))
-        self.assertEqual('thread', lupa.lua_type(x.coroutine()))
+        self.assertEqual('function', self.lupa.lua_type(x))
+        self.assertEqual('thread', self.lupa.lua_type(x.coroutine()))
 
-        self.assertEqual(None, lupa.lua_type(1))
-        self.assertEqual(None, lupa.lua_type(1.1))
-        self.assertEqual(None, lupa.lua_type('abc'))
-        self.assertEqual(None, lupa.lua_type({}))
-        self.assertEqual(None, lupa.lua_type([]))
-        self.assertEqual(None, lupa.lua_type(lupa))
-        self.assertEqual(None, lupa.lua_type(lupa.lua_type))
+        self.assertEqual(None, self.lupa.lua_type(1))
+        self.assertEqual(None, self.lupa.lua_type(1.1))
+        self.assertEqual(None, self.lupa.lua_type('abc'))
+        self.assertEqual(None, self.lupa.lua_type({}))
+        self.assertEqual(None, self.lupa.lua_type([]))
+        self.assertEqual(None, self.lupa.lua_type(self.lupa))
+        self.assertEqual(None, self.lupa.lua_type(self.lupa.lua_type))
 
     def test_call_from_coroutine(self):
         lua = self.lua
@@ -895,10 +898,10 @@ class TestLuaRuntime(SetupLuaRuntimeMixin, unittest.TestCase):
     def test_compile(self):
         lua_func = self.lua.compile('return 1 + 2')
         self.assertEqual(lua_func(), 3)
-        self.assertRaises(lupa.LuaSyntaxError, self.lua.compile, 'function awd()')
+        self.assertRaises(self.lupa.LuaSyntaxError, self.lua.compile, 'function awd()')
 
 
-class TestAttributesNoAutoEncoding(SetupLuaRuntimeMixin, unittest.TestCase):
+class TestAttributesNoAutoEncoding(SetupLuaRuntimeMixin, LupaTestCase):
     lua_runtime_kwargs = {'encoding': None}
 
     def test_pygetitem(self):
@@ -930,7 +933,7 @@ class TestAttributesNoAutoEncoding(SetupLuaRuntimeMixin, unittest.TestCase):
         self.assertEqual(123, t.ATTR)
 
 
-class TestStrNoAutoEncoding(SetupLuaRuntimeMixin, unittest.TestCase):
+class TestStrNoAutoEncoding(SetupLuaRuntimeMixin, LupaTestCase):
     lua_runtime_kwargs = {'encoding': None}
 
     def test_call_str(self):
@@ -953,10 +956,10 @@ class TestStrNoAutoEncoding(SetupLuaRuntimeMixin, unittest.TestCase):
         self.assertEqual(True, called[0])
 
 
-class TestAttributeHandlers(unittest.TestCase):
+class TestAttributeHandlers(LupaTestCase):
     def setUp(self):
-        self.lua = lupa.LuaRuntime()
-        self.lua_handling = lupa.LuaRuntime(attribute_handlers=(self.attr_getter, self.attr_setter))
+        self.lua = self.lupa.LuaRuntime()
+        self.lua_handling = self.lupa.LuaRuntime(attribute_handlers=(self.attr_getter, self.attr_setter))
 
         self.x, self.y = self.X(), self.Y()
         self.d = {'a': "aval", "b": "bval", "c": "cval"}
@@ -1008,30 +1011,30 @@ class TestAttributeHandlers(unittest.TestCase):
             obj[name] = value
 
     def test_legal_arguments(self):
-        lupa.LuaRuntime(attribute_filter=None)
-        lupa.LuaRuntime(attribute_filter=len)
-        lupa.LuaRuntime(attribute_handlers=None)
-        lupa.LuaRuntime(attribute_handlers=())
-        lupa.LuaRuntime(attribute_handlers=[len, bool])
-        lupa.LuaRuntime(attribute_handlers=iter([len, bool]))
-        lupa.LuaRuntime(attribute_handlers=(None, None))
-        lupa.LuaRuntime(attribute_handlers=iter([None, None]))
+        self.lupa.LuaRuntime(attribute_filter=None)
+        self.lupa.LuaRuntime(attribute_filter=len)
+        self.lupa.LuaRuntime(attribute_handlers=None)
+        self.lupa.LuaRuntime(attribute_handlers=())
+        self.lupa.LuaRuntime(attribute_handlers=[len, bool])
+        self.lupa.LuaRuntime(attribute_handlers=iter([len, bool]))
+        self.lupa.LuaRuntime(attribute_handlers=(None, None))
+        self.lupa.LuaRuntime(attribute_handlers=iter([None, None]))
 
     def test_illegal_arguments(self):
         self.assertRaises(
-            ValueError, lupa.LuaRuntime, attribute_filter=123)
+            ValueError, self.lupa.LuaRuntime, attribute_filter=123)
         self.assertRaises(
-            ValueError, lupa.LuaRuntime, attribute_handlers=(1, 2, 3, 4))
+            ValueError, self.lupa.LuaRuntime, attribute_handlers=(1, 2, 3, 4))
         self.assertRaises(
-            ValueError, lupa.LuaRuntime, attribute_handlers=(1,))
+            ValueError, self.lupa.LuaRuntime, attribute_handlers=(1,))
         self.assertRaises(
-            ValueError, lupa.LuaRuntime, attribute_handlers=(1, 2))
+            ValueError, self.lupa.LuaRuntime, attribute_handlers=(1, 2))
         self.assertRaises(
-            ValueError, lupa.LuaRuntime, attribute_handlers=(1, len))
+            ValueError, self.lupa.LuaRuntime, attribute_handlers=(1, len))
         self.assertRaises(
-            ValueError, lupa.LuaRuntime, attribute_handlers=(len, 2))
+            ValueError, self.lupa.LuaRuntime, attribute_handlers=(len, 2))
         self.assertRaises(
-            ValueError, lupa.LuaRuntime, attribute_handlers=(len, bool), attribute_filter=bool)
+            ValueError, self.lupa.LuaRuntime, attribute_handlers=(len, bool), attribute_filter=bool)
 
     def test_attribute_setter_normal(self):
         function = self.lua_handling.eval("function (obj) obj.a = 100 end")
@@ -1126,7 +1129,7 @@ class TestAttributeHandlers(unittest.TestCase):
         self.assertEqual(function(self.d), None)
 
 
-class TestPythonObjectsInLua(SetupLuaRuntimeMixin, unittest.TestCase):
+class TestPythonObjectsInLua(SetupLuaRuntimeMixin, LupaTestCase):
     def test_explicit_python_function(self):
         lua_func = self.lua.eval(
             'function(func)'
@@ -1219,9 +1222,9 @@ class TestPythonObjectsInLua(SetupLuaRuntimeMixin, unittest.TestCase):
     def test_python_enumerate_list_start_invalid(self):
         python_enumerate = self.lua.globals().python.enumerate
         iterator = range(10)
-        self.assertRaises(lupa.LuaError, python_enumerate, iterator, "abc")
-        self.assertRaises(lupa.LuaError, python_enumerate, iterator, self.lua.table())
-        self.assertRaises(lupa.LuaError, python_enumerate, iterator, python_enumerate)
+        self.assertRaises(self.lupa.LuaError, python_enumerate, iterator, "abc")
+        self.assertRaises(self.lupa.LuaError, python_enumerate, iterator, self.lua.table())
+        self.assertRaises(self.lupa.LuaError, python_enumerate, iterator, python_enumerate)
 
     def test_python_iter_dict_items(self):
         values = self.lua.eval('''
@@ -1233,7 +1236,7 @@ class TestPythonObjectsInLua(SetupLuaRuntimeMixin, unittest.TestCase):
                 return t
             end
         ''')
-        table = values(lupa.as_attrgetter(dict(a=1, b=2, c=3)))
+        table = values(self.lupa.as_attrgetter(dict(a=1, b=2, c=3)))
         self.assertEqual(1, table['a'])
         self.assertEqual(2, table['b'])
         self.assertEqual(3, table['c'])
@@ -1281,7 +1284,7 @@ class TestPythonObjectsInLua(SetupLuaRuntimeMixin, unittest.TestCase):
         self.assertEqual([3, 2, 1], list(values(reversed([1, 2, 3])).values()))
 
 
-class TestLuaCoroutines(SetupLuaRuntimeMixin, unittest.TestCase):
+class TestLuaCoroutines(SetupLuaRuntimeMixin, LupaTestCase):
     def test_coroutine_object(self):
         f = self.lua.eval("function(N) coroutine.yield(N) end")
         gen = f.coroutine(5)
@@ -1291,7 +1294,7 @@ class TestLuaCoroutines(SetupLuaRuntimeMixin, unittest.TestCase):
         self.assertRaises(AttributeError, getattr, gen, 'no_such_attribute')
         self.assertRaises(AttributeError, gen.__getattr__, 'no_such_attribute')
 
-        self.assertRaises(lupa.LuaError, gen.__call__)
+        self.assertRaises(self.lupa.LuaError, gen.__call__)
         self.assertTrue(hasattr(gen.send, '__call__'))
 
         self.assertRaises(TypeError, operator.itemgetter(1), gen)
@@ -1530,7 +1533,7 @@ class TestLuaCoroutines(SetupLuaRuntimeMixin, unittest.TestCase):
         self.assertEqual([0,1,0,1,0,1], result)
 
 
-class TestLuaCoroutinesWithDebugHooks(SetupLuaRuntimeMixin, unittest.TestCase):
+class TestLuaCoroutinesWithDebugHooks(SetupLuaRuntimeMixin, LupaTestCase):
 
     def _enable_hook(self):
         self.lua.execute('''
@@ -1625,7 +1628,7 @@ class TestLuaCoroutinesWithDebugHooks(SetupLuaRuntimeMixin, unittest.TestCase):
         _check()
 
 
-class TestLuaApplications(unittest.TestCase):
+class TestLuaApplications(LupaTestCase):
     def tearDown(self):
         gc.collect()
 
@@ -1659,7 +1662,7 @@ function(N)
 end
 '''
 
-        lua = lupa.LuaRuntime(encoding=None)
+        lua = self.lupa.LuaRuntime(encoding=None)
         lua_mandelbrot = lua.eval(code)
 
         image_size = 128
@@ -1677,7 +1680,7 @@ end
         ##     image.show()
 
 
-class TestLuaRuntimeEncoding(unittest.TestCase):
+class TestLuaRuntimeEncoding(LupaTestCase):
     def tearDown(self):
         gc.collect()
 
@@ -1686,7 +1689,7 @@ class TestLuaRuntimeEncoding(unittest.TestCase):
         test_string = test_string.decode('UTF-8')
 
     def _encoding_test(self, encoding, expected_length):
-        lua = lupa.LuaRuntime(encoding)
+        lua = self.lupa.LuaRuntime(encoding)
 
         self.assertEqual(unicode_type,
                          type(lua.eval(self.test_string)))
@@ -1704,35 +1707,35 @@ class TestLuaRuntimeEncoding(unittest.TestCase):
         self._encoding_test('ISO-8859-15', 6)
 
     def test_stringlib_utf8(self):
-        lua = lupa.LuaRuntime('UTF-8')
+        lua = self.lupa.LuaRuntime('UTF-8')
         stringlib = lua.eval('string')
         self.assertEqual('abc', stringlib.lower('ABC'))
 
     def test_stringlib_no_encoding(self):
-        lua = lupa.LuaRuntime(encoding=None)
+        lua = self.lupa.LuaRuntime(encoding=None)
         stringlib = lua.eval('string')
         self.assertEqual('abc'.encode('ASCII'), stringlib.lower('ABC'.encode('ASCII')))
 
 
-class TestMultipleLuaRuntimes(unittest.TestCase):
+class TestMultipleLuaRuntimes(LupaTestCase):
     def tearDown(self):
         gc.collect()
 
     def test_multiple_runtimes(self):
-        lua1 = lupa.LuaRuntime()
+        lua1 = self.lupa.LuaRuntime()
 
         function1 = lua1.eval('function() return 1 end')
         self.assertNotEqual(None, function1)
         self.assertEqual(1, function1())
 
-        lua2 = lupa.LuaRuntime()
+        lua2 = self.lupa.LuaRuntime()
 
         function2 = lua2.eval('function() return 1+1 end')
         self.assertNotEqual(None, function2)
         self.assertEqual(1, function1())
         self.assertEqual(2, function2())
 
-        lua3 = lupa.LuaRuntime()
+        lua3 = self.lupa.LuaRuntime()
 
         self.assertEqual(1, function1())
         self.assertEqual(2, function2())
@@ -1747,7 +1750,7 @@ class TestMultipleLuaRuntimes(unittest.TestCase):
         self.assertEqual(3, function3())
 
 
-class TestThreading(unittest.TestCase):
+class TestThreading(LupaTestCase):
     def tearDown(self):
         gc.collect()
 
@@ -1770,7 +1773,7 @@ class TestThreading(unittest.TestCase):
         end
         return calc
         '''
-        lua = lupa.LuaRuntime()
+        lua = self.lupa.LuaRuntime()
         functions = [ lua.execute(func_code) for _ in range(10) ]
         results = [None] * len(functions)
 
@@ -1797,7 +1800,7 @@ class TestThreading(unittest.TestCase):
         end
         return calc
         '''
-        runtimes  = [ lupa.LuaRuntime() for _ in range(10) ]
+        runtimes  = [ self.lupa.LuaRuntime() for _ in range(10) ]
         functions = [ lua.execute(func_code) for lua in runtimes ]
 
         results = [None] * len(runtimes)
@@ -1823,7 +1826,7 @@ class TestThreading(unittest.TestCase):
         end
         return calc
         '''
-        runtimes  = [ lupa.LuaRuntime() for _ in range(10) ]
+        runtimes  = [ self.lupa.LuaRuntime() for _ in range(10) ]
         functions = [ lua.execute(func_code) for lua in runtimes ]
 
         results = [None] * len(runtimes)
@@ -1844,7 +1847,7 @@ class TestThreading(unittest.TestCase):
 
     def test_threading_iter(self):
         values = list(range(1,100))
-        lua = lupa.LuaRuntime()
+        lua = self.lupa.LuaRuntime()
         table = lua.eval('{%s}' % ','.join(map(str, values)))
         self.assertEqual(values, list(table))
 
@@ -1924,7 +1927,7 @@ class TestThreading(unittest.TestCase):
         image_size = 128
         thread_count = 4
 
-        lua_funcs = [ lupa.LuaRuntime(encoding=None).eval(code)
+        lua_funcs = [ self.lupa.LuaRuntime(encoding=None).eval(code)
                       for _ in range(thread_count) ]
 
         results = [None] * thread_count
@@ -1958,9 +1961,9 @@ class TestThreading(unittest.TestCase):
         ##     image.show()
 
 
-class TestDontUnpackTuples(unittest.TestCase):
+class TestDontUnpackTuples(LupaTestCase):
     def setUp(self):
-        self.lua = lupa.LuaRuntime()  # default is unpack_returned_tuples=False
+        self.lua = self.lupa.LuaRuntime()  # default is unpack_returned_tuples=False
 
         # Define a Python function which returns a tuple
         # and is accessible from Lua as fun().
@@ -1983,9 +1986,9 @@ class TestDontUnpackTuples(unittest.TestCase):
         self.assertEqual(("one", "two", "three", "four"), self.lua.eval("a"))
 
 
-class TestUnpackTuples(unittest.TestCase):
+class TestUnpackTuples(LupaTestCase):
     def setUp(self):
-        self.lua = lupa.LuaRuntime(unpack_returned_tuples=True)
+        self.lua = self.lupa.LuaRuntime(unpack_returned_tuples=True)
 
         # Define a Python function which returns a tuple
         # and is accessible from Lua as fun().
@@ -2080,10 +2083,10 @@ class TestUnpackTuples(unittest.TestCase):
                          list(values(zip([10, 20, 30], [20, 30, 40])).values()))
 
 
-class TestMethodCall(unittest.TestCase):
+class TestMethodCall(LupaTestCase):
     def setUp(self):
 
-        self.lua = lupa.LuaRuntime(unpack_returned_tuples=True)
+        self.lua = self.lupa.LuaRuntime(unpack_returned_tuples=True)
 
         class C(object):
             def __init__(self, x):
@@ -2233,7 +2236,7 @@ class MyCls_3(object):
         return ("x=%s, y=%s, z=%s" % (x, y, z))
 
 
-class KwargsDecoratorTest(SetupLuaRuntimeMixin, unittest.TestCase):
+class KwargsDecoratorTest(SetupLuaRuntimeMixin, LupaTestCase):
 
     def __init__(self, *args, **kwargs):
         super(KwargsDecoratorTest, self).__init__(*args, **kwargs)
@@ -2383,7 +2386,7 @@ def _wait():
     time.sleep(0.01)
 
 
-class TestFastRLock(unittest.TestCase):
+class TestFastRLock(LupaTestCase):
     """Copied from CPython's test.lock_tests module
     """
     FastRLock = None
@@ -2614,7 +2617,7 @@ class TestFastRLock(unittest.TestCase):
 ################################################################################
 # tests for error stacktrace
 
-class TestErrorStackTrace(unittest.TestCase):
+class TestErrorStackTrace(LupaTestCase):
     if not hasattr(unittest.TestCase, 'assertIn'):
         def assertIn(self, member, container, msg=None):
             self.assertTrue(member in container, msg)
@@ -2624,36 +2627,36 @@ class TestErrorStackTrace(unittest.TestCase):
             self.assertFalse(member in container, msg)
 
     def test_stacktrace(self):
-        lua = lupa.LuaRuntime()
+        lua = self.lupa.LuaRuntime()
         try:
             lua.execute("error('abc')")
             raise RuntimeError("LuaError was not raised")
-        except lupa.LuaError as e:
+        except self.lupa.LuaError as e:
             self.assertIn("stack traceback:", e.args[0])
 
     def test_nil_debug(self):
-        lua = lupa.LuaRuntime()
+        lua = self.lupa.LuaRuntime()
         try:
             lua.execute("debug = nil")
             lua.execute("error('abc')")
             raise RuntimeError("LuaError was not raised")
-        except lupa.LuaError as e:
+        except self.lupa.LuaError as e:
             self.assertNotIn("stack traceback:", e.args[0])
 
     def test_nil_debug_traceback(self):
-        lua = lupa.LuaRuntime()
+        lua = self.lupa.LuaRuntime()
         try:
             lua.execute("debug = nil")
             lua.execute("error('abc')")
             raise RuntimeError("LuaError was not raised")
-        except lupa.LuaError as e:
+        except self.lupa.LuaError as e:
             self.assertNotIn("stack traceback:", e.args[0])
 
 
 ################################################################################
 # tests for keyword arguments
 
-class PythonArgumentsInLuaTest(SetupLuaRuntimeMixin, unittest.TestCase):
+class PythonArgumentsInLuaTest(SetupLuaRuntimeMixin, LupaTestCase):
 
     @staticmethod
     def get_args(*args, **kwargs):
@@ -2668,8 +2671,8 @@ class PythonArgumentsInLuaTest(SetupLuaRuntimeMixin, unittest.TestCase):
         return None
 
     def assertEqualInLua(self, a, b):
-        lua_type_a = lupa.lua_type(a)
-        lua_type_b = lupa.lua_type(b)
+        lua_type_a = self.lupa.lua_type(a)
+        lua_type_b = self.lupa.lua_type(b)
         if lua_type_a and lua_type_b and lua_type_a == lua_type_b:
             return self.lua.eval('function(a, b) return a == b end')(a, b)
         return self.assertEqual(a, b)
@@ -2694,7 +2697,7 @@ class PythonArgumentsInLuaTest(SetupLuaRuntimeMixin, unittest.TestCase):
         self.assertRaisesRegex(error, regex, lua_func, self.get_none)
 
     def test_no_table(self):
-        self.assertIncorrect('python.args()', error=lupa.LuaError)
+        self.assertIncorrect('python.args()', error=self.lupa.LuaError)
 
     def test_no_args(self):
         self.assertResult('python.args{}', (), {})
@@ -2729,7 +2732,7 @@ class PythonArgumentsInLuaTest(SetupLuaRuntimeMixin, unittest.TestCase):
         for objtype in kwargs:
             if objtype != 'table':
                 self.assertIncorrect('python.args(kwargs["%s"])' % objtype,
-                        error=lupa.LuaError, regex="bad argument #1 to 'args'")
+                        error=self.lupa.LuaError, regex="bad argument #1 to 'args'")
         
         # Invalid table keys
         self.assertIncorrect('python.args{[0] = true}', error=IndexError, regex='table index out of range')
@@ -2769,7 +2772,7 @@ class PythonArgumentsInLuaMethodsTest(PythonArgumentsInLuaTest):
 ################################################################################
 # tests for table access error
 
-class TestTableAccessError(SetupLuaRuntimeMixin, unittest.TestCase):
+class TestTableAccessError(SetupLuaRuntimeMixin, LupaTestCase):
     def test_error_index_metamethod(self):
         self.lua.execute('''
         t = {}
@@ -2780,7 +2783,7 @@ class TestTableAccessError(SetupLuaRuntimeMixin, unittest.TestCase):
         end})
         ''')
         lua_t = self.lua.eval('t')
-        self.assertRaisesRegex(lupa.LuaError, 'my error message', lambda t, k: t[k], lua_t, 'k')
+        self.assertRaisesRegex(self.lupa.LuaError, 'my error message', lambda t, k: t[k], lua_t, 'k')
         self.assertEqual(self.lua.eval('called'), 1)
 
 
@@ -2788,16 +2791,17 @@ class TestTableAccessError(SetupLuaRuntimeMixin, unittest.TestCase):
 # tests for handling overflow
 
 class TestOverflowMixin(SetupLuaRuntimeMixin):
-    maxinteger = lupa.LUA_MAXINTEGER    # maximum value for Lua integer
-    mininteger = lupa.LUA_MININTEGER    # minimum value for Lua integer
-    biginteger = (maxinteger + 1) << 1  # value too big to fit in a Lua integer
-    maxfloat = sys.float_info.max       # maximum value for Python float
-    bigfloat = int(maxfloat) * 2        # value too big to fit in Python float
-
-    assert biginteger <= maxfloat, "%d can't be cast to float" % biginteger
-
     def setUp(self):
         super(TestOverflowMixin, self).setUp()
+
+        self.maxinteger = self.lupa.LUA_MAXINTEGER  # maximum value for Lua integer
+        self.mininteger = self.lupa.LUA_MININTEGER  # minimum value for Lua integer
+        self.biginteger = (self.maxinteger + 1) << 1  # value too big to fit in a Lua integer
+        self.maxfloat = sys.float_info.max  # maximum value for Python float
+        self.bigfloat = int(self.maxfloat) * 2  # value too big to fit in Python float
+
+        assert self.biginteger <= self.maxfloat, "%d can't be cast to float" % self.biginteger
+
         self.lua_type = self.lua.eval('type')
         self.lua_math_type = self.lua.eval('math.type')
 
@@ -2827,7 +2831,7 @@ class TestOverflowMixin(SetupLuaRuntimeMixin):
             self.assertEqual(self.lua_math_type(number), math_type)
 
 
-class TestOverflowWithoutHandler(TestOverflowMixin, unittest.TestCase):
+class TestOverflowWithoutHandler(TestOverflowMixin, LupaTestCase):
     lua_runtime_kwargs = dict(overflow_handler=None)
 
     def test_overflow(self):
@@ -2836,7 +2840,7 @@ class TestOverflowWithoutHandler(TestOverflowMixin, unittest.TestCase):
         self.assertRaises(OverflowError, self.assertMathType, self.bigfloat, 'integer')
 
 
-class TestOverflowWithFloatHandler(TestOverflowMixin, unittest.TestCase):
+class TestOverflowWithFloatHandler(TestOverflowMixin, LupaTestCase):
     lua_runtime_kwargs = dict(overflow_handler=float)
 
     def test_overflow(self):
@@ -2845,13 +2849,13 @@ class TestOverflowWithFloatHandler(TestOverflowMixin, unittest.TestCase):
         self.assertRaises(OverflowError, self.assertMathType, self.bigfloat, 'float')
 
 
-class TestOverflowWithObjectHandler(TestOverflowMixin, unittest.TestCase):
+class TestOverflowWithObjectHandler(TestOverflowMixin, LupaTestCase):
     def test_overflow(self):
         self.lua.execute('python.set_overflow_handler(function(o) return o end)')
         self.assertEqual(self.lua.eval('type')(self.biginteger), 'userdata')
 
 
-class TestFloatOverflowHandlerInLua(TestOverflowMixin, unittest.TestCase):
+class TestFloatOverflowHandlerInLua(TestOverflowMixin, LupaTestCase):
     def test_overflow(self):
         self.lua.execute('python.set_overflow_handler(python.builtins.float)')
         self.assertMathType(self.biginteger, 'float')
@@ -2859,14 +2863,14 @@ class TestFloatOverflowHandlerInLua(TestOverflowMixin, unittest.TestCase):
         self.assertRaises(OverflowError, self.assertMathType, self.bigfloat, 'float')
 
 
-class TestBadOverflowHandlerInPython(unittest.TestCase):
+class TestBadOverflowHandlerInPython(LupaTestCase):
     def test_error(self):
-        self.assertRaises(ValueError, lupa.LuaRuntime, overflow_handler=123)
+        self.assertRaises(ValueError, self.lupa.LuaRuntime, overflow_handler=123)
 
 
-class TestBadOverflowHandlerInLua(SetupLuaRuntimeMixin, unittest.TestCase):
+class TestBadOverflowHandlerInLua(SetupLuaRuntimeMixin, LupaTestCase):
     def _test_set_overflow_handler(self, overflow_handler_code):
-        self.assertRaises(lupa.LuaError, self.lua.execute, 'python.set_overflow_handler(%s)' % overflow_handler_code)
+        self.assertRaises(self.lupa.LuaError, self.lua.execute, 'python.set_overflow_handler(%s)' % overflow_handler_code)
 
     def test_number(self):
         self._test_set_overflow_handler('123')
@@ -2885,7 +2889,7 @@ class TestBadOverflowHandlerInLua(SetupLuaRuntimeMixin, unittest.TestCase):
         self._test_set_overflow_handler('coroutine.create(function() end)')
 
 
-class TestOverflowHandlerOverwrite(TestOverflowMixin, unittest.TestCase):
+class TestOverflowHandlerOverwrite(TestOverflowMixin, LupaTestCase):
     lua_runtime_kwargs = dict(overflow_handler=float)
 
     def test_overwrite_in_lua(self):
@@ -2912,7 +2916,7 @@ class TestOverflowHandlerOverwrite(TestOverflowMixin, unittest.TestCase):
 ################################################################################
 # tests for missing reference
 
-class TestMissingReference(SetupLuaRuntimeMixin, unittest.TestCase):
+class TestMissingReference(SetupLuaRuntimeMixin, LupaTestCase):
     def setUp(self):
         super(TestMissingReference, self).setUp()
         self.testmissingref = self.lua.eval('''
@@ -2952,25 +2956,25 @@ class TestMissingReference(SetupLuaRuntimeMixin, unittest.TestCase):
 
         self.testmissingref({}, lambda o: str(o))                            # __tostring
         self.testmissingref({}, lambda o: o[1])                              # __index
-        self.testmissingref({}, lambda o: lupa.as_itemgetter(o)[1])          # __index (itemgetter)
-        self.testmissingref({}, lambda o: lupa.as_attrgetter(o).items)       # __index (attrgetter)
+        self.testmissingref({}, lambda o: self.lupa.as_itemgetter(o)[1])          # __index (itemgetter)
+        self.testmissingref({}, lambda o: self.lupa.as_attrgetter(o).items)       # __index (attrgetter)
         self.testmissingref({}, lambda o: assign(o[1]))                      # __newindex
-        self.testmissingref({}, lambda o: assign(lupa.as_itemgetter(o)[1]))  # __newindex (itemgetter)
-        self.testmissingref(X(), lambda o: assign(lupa.as_attrgetter(o).a))  # __newindex (attrgetter)
+        self.testmissingref({}, lambda o: assign(self.lupa.as_itemgetter(o)[1]))  # __newindex (itemgetter)
+        self.testmissingref(X(), lambda o: assign(self.lupa.as_attrgetter(o).a))  # __newindex (attrgetter)
         self.testmissingref(X(), lambda o: o())                              # __call
 
     def test_functions(self):
         self.testmissingref({}, print)              # reflection
         self.testmissingref({}, iter)               # iteration
         self.testmissingref({}, enumerate)          # enumerate
-        self.testmissingref({}, lupa.as_itemgetter) # item getter protocol
-        self.testmissingref({}, lupa.as_attrgetter) # attribute getter protocol
+        self.testmissingref({}, self.lupa.as_itemgetter) # item getter protocol
+        self.testmissingref({}, self.lupa.as_attrgetter) # attribute getter protocol
 
 
 ################################################################################
 # test Lua object __str__ method
 
-class TestLuaObjectString(SetupLuaRuntimeMixin, unittest.TestCase):
+class TestLuaObjectString(SetupLuaRuntimeMixin, LupaTestCase):
     def test_normal_string(self):
         self.assertIn('Lua table', str(self.lua.eval('{}')))
         self.assertIn('Lua function', str(self.lua.eval('print')))
@@ -2981,7 +2985,15 @@ class TestLuaObjectString(SetupLuaRuntimeMixin, unittest.TestCase):
                 str, self.lua.eval('setmetatable({}, {__tostring = function() end})'))
 
     def test_tostring_err(self):
-        self.assertRaises(lupa.LuaError, str, self.lua.eval('setmetatable({}, {__tostring = function() error() end})'))
+        self.assertRaises(self.lupa.LuaError, str, self.lua.eval('setmetatable({}, {__tostring = function() error() end})'))
+
+
+
+################################################################################
+# Load tests for different Lua version modules
+
+def load_tests(loader, standard_tests, pattern):
+    return lupa.tests.build_suite_for_modules(loader, globals())
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Cython>=0.29.28
+Cython>=0.29.32
 setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Cython>=0.29.24
+Cython>=0.29.28
 setuptools

--- a/setup.py
+++ b/setup.py
@@ -366,7 +366,7 @@ def prepare_extensions(use_cython=True):
     ext_modules = []
     ext_libraries = []
     for config in configs:
-        ext_name = 'lupa_%s' % config.get('libversion', 'lua')
+        ext_name = config.get('libversion', 'lua')
         src, dst = os.path.join('lupa', '_lupa.pyx'), os.path.join('lupa', ext_name + '.pyx')
         if not os.path.exists(dst) or os.path.getmtime(dst) < os.path.getmtime(src):
             with open(dst, 'wb') as f_out:

--- a/setup.py
+++ b/setup.py
@@ -350,6 +350,9 @@ if not configs and not option_no_bundle:
             # http://t-p-j.blogspot.com/2010/11/lupa-on-os-x-with-macports-python-26.html
             # LuaJIT 2.1-alpha3 fails at runtime.
             or (platform == 'darwin' and 'luajit' in os.path.basename(lua_bundle_path.rstrip(os.sep)))
+            # Couldn't get the Windows build to work. See
+            # https://luajit.org/install.html#windows
+            or (platform.startswith('win') and 'luajit' in os.path.basename(lua_bundle_path.rstrip(os.sep)))
         )
     ]
 if not configs and not option_use_bundle:

--- a/setup.py
+++ b/setup.py
@@ -233,7 +233,10 @@ def use_bundled_luajit(path, macros):
 
     src_dir = os.path.join(path, "src")
     output = subprocess.check_output(build_script, cwd=src_dir)
-    assert b'Successfully built LuaJIT' in output
+    if b'Successfully built LuaJIT' not in output:
+        print("Building LuaJIT did not report success:")
+        print(output)
+        print("## Building LuaJIT probably failed ##")
 
     return {
         'include_dirs': [src_dir],

--- a/setup.py
+++ b/setup.py
@@ -349,7 +349,7 @@ if not configs and not option_no_bundle:
             # LuaJIT 2.0 on macOS requires a CPython linked with "-pagezero_size 10000 -image_base 100000000"
             # http://t-p-j.blogspot.com/2010/11/lupa-on-os-x-with-macports-python-26.html
             # LuaJIT 2.1-alpha3 fails at runtime.
-            or (platform == 'darwin' and 'luajit' in os.path.basename(lua_bundle_path))
+            or (platform == 'darwin' and 'luajit' in os.path.basename(lua_bundle_path.rstrip(os.sep)))
         )
     ]
 if not configs and not option_use_bundle:

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,14 @@
 from __future__ import absolute_import
 
-import sys
-import shutil
+import glob
 import os
 import os.path
+import re
+import shutil
+import sys
 
 from glob import iglob
-from io import open
+from io import open as io_open
 
 try:
     # use setuptools if available
@@ -17,6 +19,8 @@ except ImportError:
 VERSION = '2.0a1'
 
 extra_setup_args = {}
+
+basedir = os.path.abspath(os.path.dirname(__file__))
 
 
 # support 'test' target if setuptools/distribute is available
@@ -124,26 +128,29 @@ def lua_libs(package='luajit'):
     return libs_out.split()
 
 
-basedir = os.path.abspath(os.path.dirname(__file__))
-
 def get_lua_build_from_arguments():
     lua_lib = get_option('--lua-lib')
     lua_includes = get_option('--lua-includes')
 
     if not lua_lib or not lua_includes:
-        return None
+        return []
 
     print('Using Lua library: %s' % lua_lib)
     print('Using Lua include directory: %s' % lua_includes)
 
     root, ext = os.path.splitext(lua_lib)
     if os.name == 'nt' and ext == '.lib':
-        return dict(extra_objects=[lua_lib],
-                    include_dirs=[lua_includes],
-                    libfile=lua_lib)
+        return [
+            dict(extra_objects=[lua_lib],
+                 include_dirs=[lua_includes],
+                 libfile=lua_lib)
+        ]
     else:
-        return dict(extra_objects=[lua_lib],
-                    include_dirs=[lua_includes])
+        return [
+            dict(extra_objects=[lua_lib],
+                 include_dirs=[lua_includes])
+        ]
+
 
 def find_lua_build(no_luajit=False):
     # try to find local LuaJIT2 build
@@ -210,10 +217,38 @@ def no_lua_error():
     return {}
 
 
-def use_bundled_lua(path, lua_sources, macros):
-    print('Using bundled Lua')
+def use_bundled_lua(path, macros):
+    libname = os.path.basename(path.rstrip(os.sep))
+    print('Using bundled Lua in %s' % libname)
+
+    # Parse .o files from 'makefile'
+    makefile = os.path.join(path, "makefile")
+    match_var = re.compile(r"(CORE|AUX|LIB|ALL)_O\s*=(.*)").match
+    is_indented = re.compile(r"\s+").match
+
+    obj_files = []
+    continuing = False
+    with open(makefile) as f:
+        lines = iter(f)
+        for line in lines:
+            if '#' in line:
+                line = line.partition("#")[0]
+            line = line.rstrip()
+            if not line:
+                continue
+            match = match_var(line)
+            if match:
+                if match.group(1) == 'ALL':
+                    break  # by now, we should have seen all that we needed
+                obj_files.extend(match.group(2).rstrip('\\').split())
+                continuing = line.endswith('\\')
+            elif continuing and is_indented(line):
+                obj_files.extend(line.rstrip('\\').split())
+                continuing = line.endswith('\\')
+
+    lua_sources = [os.path.splitext(obj_file)[0] + '.c' for obj_file in obj_files]
     ext_libraries = [
-        ['lua', {
+        [libname, {
             'sources': [os.path.join(path, src) for src in lua_sources],
             'include_dirs': [path],
             'macros': macros,
@@ -222,6 +257,7 @@ def use_bundled_lua(path, lua_sources, macros):
     return {
         'include_dirs': [path],
         'ext_libraries': ext_libraries,
+        'libversion': libname,
     }
 
 
@@ -250,99 +286,76 @@ if has_option('--with-lua-checks'):
     c_defines.append(('LUA_USE_APICHECK', None))
 
 
-# bundled lua
-lua_bundle_path = os.path.join(basedir, 'third-party', 'lua')
-lua_sources = [
-    'lapi.c',
-    'lcode.c',
-    'lctype.c',
-    'ldebug.c',
-    'ldo.c',
-    'ldump.c',
-    'lfunc.c',
-    'lgc.c',
-    'llex.c',
-    'lmem.c',
-    'lobject.c',
-    'lopcodes.c',
-    'lparser.c',
-    'lstate.c',
-    'lstring.c',
-    'ltable.c',
-    'ltm.c',
-    'lundump.c',
-    'lvm.c',
-    'lzio.c',
-    'ltests.c',
-    'lauxlib.c',
-    'lbaselib.c',
-    'ldblib.c',
-    'liolib.c',
-    'lmathlib.c',
-    'loslib.c',
-    'ltablib.c',
-    'lstrlib.c',
-    'lutf8lib.c',
-    'loadlib.c',
-    'lcorolib.c',
-    'linit.c',
-]
-
-config = get_lua_build_from_arguments()
-if not config and not has_option('--use-bundle'):
-    config = find_lua_build(no_luajit=has_option('--no-luajit'))
-if not config and not has_option('--no-bundle'):
-    config = use_bundled_lua(lua_bundle_path, lua_sources, c_defines)
-if not config:
-    config = no_lua_error()
-
-ext_args = {
-    'extra_objects': config.get('extra_objects'),
-    'include_dirs': config.get('include_dirs'),
-    'define_macros': c_defines,
-}
+# find Lua
+configs = get_lua_build_from_arguments()
+if not configs and not has_option('--no-bundle'):
+    configs = [
+        use_bundled_lua(lua_bundle_path, c_defines)
+        for lua_bundle_path in glob.glob(os.path.join(basedir, 'third-party', 'lua5*' + os.sep))
+        if not lua_bundle_path.endswith('lua52' + os.sep)  # 5.2.3 fails to compile
+    ]
+if not configs and not has_option('--use-bundle'):
+    configs = find_lua_build(no_luajit=has_option('--no-luajit'))
+if not configs:
+    configs = no_lua_error()
 
 
 # check if Cython is installed, and use it if requested or necessary
-use_cython = has_option('--with-cython')
-if not use_cython:
-    if not os.path.exists(os.path.join(basedir, 'lupa', '_lupa.c')):
-        print("generated sources not available, need Cython to build")
-        use_cython = True
+def prepare_extensions(use_cython=True):
+    ext_modules = []
+    ext_libraries = []
+    for config in configs:
+        ext_name = 'lupa_%s' % config.get('libversion', 'lua')
+        src, dst = os.path.join('lupa', '_lupa.pyx'), os.path.join('lupa', ext_name + '.pyx')
+        if not os.path.exists(dst) or os.path.getmtime(dst) < os.path.getmtime(src):
+            with open(dst, 'wb') as f_out:
+                f_out.write(b'#######  DO NOT EDIT - BUILD TIME COPY OF "_lupa.pyx" #######\n\n')
+                with open(src, 'rb') as f_in:
+                    shutil.copyfileobj(f_in, f_out)
 
-cythonize = None
-source_extension = ".c"
-if use_cython:
-    try:
-        import Cython.Compiler.Version
-        import Cython.Compiler.Errors as CythonErrors
-        from Cython.Build import cythonize
-        print("building with Cython " + Cython.Compiler.Version.version)
-        source_extension = ".pyx"
-        CythonErrors.LEVEL = 0
-    except ImportError:
-        print("WARNING: trying to build with Cython, but it is not installed")
-else:
-    print("building without Cython")
+        libs = config.get('ext_libraries')
+        ext_modules.append(Extension(
+            'lupa.' + ext_name,
+            sources=[dst] + (libs[0][1]['sources'] if libs else []),
+            extra_objects=config.get('extra_objects'),
+            include_dirs=config.get('include_dirs'),
+            define_macros=c_defines,
+        ))
 
-ext_modules = [
-    Extension(
-        'lupa._lupa',
-        sources=[os.path.join('lupa', '_lupa'+source_extension)],
-        **ext_args
-    )]
+        if not use_cython:
+            if not os.path.exists(os.path.join(basedir, 'lupa', '_lupa.c')):
+                print("generated sources not available, need Cython to build")
+                use_cython = True
 
-if cythonize is not None:
-    ext_modules = cythonize(ext_modules)
+    cythonize = None
+    if use_cython:
+        try:
+            import Cython.Compiler.Version
+            import Cython.Compiler.Errors as CythonErrors
+            from Cython.Build import cythonize
+            print("building with Cython " + Cython.Compiler.Version.version)
+            CythonErrors.LEVEL = 0
+        except ImportError:
+            print("WARNING: trying to build with Cython, but it is not installed")
+    else:
+        print("building without Cython")
+
+    if cythonize is not None:
+        ext_modules = cythonize(ext_modules)
+
+    return ext_modules, ext_libraries
+
+
+ext_modules, ext_libraries = prepare_extensions(use_cython=has_option('--with-cython'))
 
 
 def read_file(filename):
-    with open(os.path.join(basedir, filename), encoding="utf8") as f:
+    with io_open(os.path.join(basedir, filename), encoding="utf8") as f:
         return f.read()
 
 
 def write_file(filename, content):
-    with open(os.path.join(basedir, filename), 'w', encoding='us-ascii') as f:
+    with io_open(os.path.join(basedir, filename), 'w', encoding='us-ascii') as f:
         f.write(content)
 
 
@@ -352,12 +365,16 @@ long_description = '\n\n'.join([
 
 write_file(os.path.join(basedir, 'lupa', 'version.py'), u"__version__ = '%s'\n" % VERSION)
 
-if config.get('libfile'):
-    # include Lua DLL in the lib folder if we are on Windows
-    dllfile = os.path.splitext(config['libfile'])[0] + ".dll"
-    shutil.copy(dllfile, os.path.join(basedir, 'lupa'))
-    extra_setup_args['package_data'] = {'lupa': [os.path.basename(dllfile)]}
+dll_files = []
+for config in configs:
+    if config.get('libfile'):
+        # include Lua DLL in the lib folder if we are on Windows
+        dll_file = os.path.splitext(config['libfile'])[0] + ".dll"
+        shutil.copy(dll_file, os.path.join(basedir, 'lupa'))
+        dll_files.append(os.path.basename(dll_file))
 
+if dll_files:
+    extra_setup_args['package_data'] = {'lupa': dll_files}
 
 # call distutils
 
@@ -393,7 +410,8 @@ setup(
     ],
 
     packages=['lupa'],
+    build_requires=['Cython>=0.29.28'],
     ext_modules=ext_modules,
-    libraries=config.get('ext_libraries'),
+    libraries=ext_libraries,
     **extra_setup_args
 )

--- a/setup.py
+++ b/setup.py
@@ -287,15 +287,19 @@ if has_option('--with-lua-checks'):
 
 
 # find Lua
+option_no_bundle = has_option('--no-bundle')
+option_use_bundle = has_option('--use-bundle')
+option_no_luajit = has_option('--no-luajit')
+
 configs = get_lua_build_from_arguments()
-if not configs and not has_option('--no-bundle'):
+if not configs and not option_no_bundle:
     configs = [
         use_bundled_lua(lua_bundle_path, c_defines)
         for lua_bundle_path in glob.glob(os.path.join(basedir, 'third-party', 'lua5*' + os.sep))
         if not lua_bundle_path.endswith('lua52' + os.sep)  # 5.2.3 fails to compile
     ]
-if not configs and not has_option('--use-bundle'):
-    configs = find_lua_build(no_luajit=has_option('--no-luajit'))
+if not configs and not option_use_bundle:
+    configs = find_lua_build(no_luajit=option_no_luajit)
 if not configs:
     configs = no_lua_error()
 

--- a/setup.py
+++ b/setup.py
@@ -224,14 +224,16 @@ def use_bundled_luajit(path, macros):
     print('Using bundled LuaJIT in %s' % libname)
     print('Building LuaJIT in %s' % libname)
 
-    src_dir = os.path.join(path, "src")
     if sys.platform.startswith('win'):
-        build_script = os.path.join(src_dir, "msvcbuild.bat")
+        build_script = "msvcbuild"
         lib_file = "lua51.lib"
     else:
-        build_script = "make"
+        build_script = ["make",  "libluajit.a"]
         lib_file = "libluajit.a"
-    subprocess.check_call(build_script, cwd=src_dir)
+
+    src_dir = os.path.join(path, "src")
+    output = subprocess.check_output(build_script, cwd=src_dir)
+    assert b'Successfully built LuaJIT' in output
 
     return {
         'include_dirs': [src_dir],

--- a/setup.py
+++ b/setup.py
@@ -346,9 +346,10 @@ if not configs and not option_no_bundle:
             False
             # Lua 5.2.3 fails to build
             or lua_bundle_path.endswith('lua52' + os.sep)
-            # LuaJIT 2.0 requires a CPython linked with "-pagezero_size 10000 -image_base 100000000"
+            # LuaJIT 2.0 on macOS requires a CPython linked with "-pagezero_size 10000 -image_base 100000000"
             # http://t-p-j.blogspot.com/2010/11/lupa-on-os-x-with-macports-python-26.html
-            or (platform == 'darwin' and lua_bundle_path.endswith('luajit20' + os.sep))
+            # LuaJIT 2.1-alpha3 fails at runtime.
+            or (platform == 'darwin' and 'luajit' in os.path.basename(lua_bundle_path))
         )
     ]
 if not configs and not option_use_bundle:

--- a/setup.py
+++ b/setup.py
@@ -225,7 +225,7 @@ def use_bundled_luajit(path, macros):
     print('Building LuaJIT for %r in %s' % (sys.platform, libname))
 
     if sys.platform.startswith('win'):
-        build_script = "msvcbuild"
+        build_script = ["msvcbuild", "static"]
         lib_file = "lua51.lib"
     else:
         build_script = ["make",  "libluajit.a"]
@@ -233,9 +233,9 @@ def use_bundled_luajit(path, macros):
 
     src_dir = os.path.join(path, "src")
     output = subprocess.check_output(build_script, cwd=src_dir)
-    if b'Successfully built LuaJIT' not in output:
+    if lib_file.encode("ascii") not in output:
         print("Building LuaJIT did not report success:")
-        print(output)
+        print(output.decode().strip())
         print("## Building LuaJIT may have failed ##")
 
     return {

--- a/setup.py
+++ b/setup.py
@@ -227,7 +227,7 @@ def use_bundled_luajit(path, macros):
 
     extra_link_args = None
     if platform.startswith('win'):
-        build_script = ["msvcbuild", "static"]
+        build_script = ["msvcbuild.bat", "static"]
         lib_file = "lua51.lib"
     else:
         build_script = ["make",  "libluajit.a"]

--- a/setup.py
+++ b/setup.py
@@ -225,14 +225,14 @@ def use_bundled_luajit(path, macros):
     print('Using bundled LuaJIT in %s' % libname)
     print('Building LuaJIT for %r in %s' % (platform, libname))
 
+    src_dir = os.path.join(path, "src")
     if platform.startswith('win'):
-        build_script = ["msvcbuild.bat", "static"]
+        build_script = [os.path.join(src_dir, "msvcbuild.bat"), "static"]
         lib_file = "lua51.lib"
     else:
         build_script = ["make",  "libluajit.a"]
         lib_file = "libluajit.a"
 
-    src_dir = os.path.join(path, "src")
     output = subprocess.check_output(build_script, cwd=src_dir)
     if lib_file.encode("ascii") not in output:
         print("Building LuaJIT did not report success:")

--- a/setup.py
+++ b/setup.py
@@ -222,7 +222,7 @@ def use_bundled_luajit(path, macros):
     libname = os.path.basename(path.rstrip(os.sep))
     assert 'luajit' in libname, libname
     print('Using bundled LuaJIT in %s' % libname)
-    print('Building LuaJIT in %s' % libname)
+    print('Building LuaJIT for %r in %s' % (sys.platform, libname))
 
     if sys.platform.startswith('win'):
         build_script = "msvcbuild"
@@ -236,12 +236,11 @@ def use_bundled_luajit(path, macros):
     if b'Successfully built LuaJIT' not in output:
         print("Building LuaJIT did not report success:")
         print(output)
-        print("## Building LuaJIT probably failed ##")
+        print("## Building LuaJIT may have failed ##")
 
     return {
         'include_dirs': [src_dir],
         'extra_objects': [os.path.join(src_dir, lib_file)],
-        'ext_libraries': None,
         'libversion': libname,
     }
 


### PR DESCRIPTION
Currently lacks support for building the bundled LuaJIT on Windows (and macOS, but that's a different story).
Also, building Lua 5.2.3 currently fails and thus isn't integrated.

Closes https://github.com/scoder/lupa/issues/196