### PR TITLE
Added option to pass already created LuaState

### DIFF
--- a/lupa/_lupa.pyx
+++ b/lupa/_lupa.pyx
@@ -232,6 +232,7 @@ cdef class LuaRuntime:
       >>> lua_func(py_add1, 2)
       3
     """
+    cdef bint _lua_allocated
     cdef lua_State *_state
     cdef FastRLock _lock
     cdef dict _pyrefs_in_lua
@@ -243,11 +244,17 @@ cdef class LuaRuntime:
     cdef object _attribute_setter
     cdef bint _unpack_returned_tuples
 
-    def __cinit__(self, encoding='UTF-8', source_encoding=None,
+    def __cinit__(self, state=None, encoding='UTF-8', source_encoding=None,
                   attribute_filter=None, attribute_handlers=None,
                   bint register_eval=True, bint unpack_returned_tuples=False,
                   bint register_builtins=True, overflow_handler=None):
-        cdef lua_State* L = lua.luaL_newstate()
+
+        cdef lua_State *L = <lua_State*>state;
+        self._lua_allocated = False
+        if state is None:
+            self._lua_allocated = True
+            L = lua.luaL_newstate()
+
         if L is NULL:
             raise LuaError("Failed to initialise Lua runtime")
         self._state = L
@@ -276,14 +283,16 @@ cdef class LuaRuntime:
                 raise ValueError("attribute_filter and attribute_handlers are mutually exclusive")
             self._attribute_getter, self._attribute_setter = getter, setter
 
-        lua.luaL_openlibs(L)
+        if self._lua_allocated:
+            lua.luaL_openlibs(L)
+            
         self.init_python_lib(register_eval, register_builtins)
         lua.lua_atpanic(L, <lua.lua_CFunction>1)
 
         self.set_overflow_handler(overflow_handler)
 
     def __dealloc__(self):
-        if self._state is not NULL:
+        if self._state is not NULL and self._lua_allocated:
             lua.lua_close(self._state)
             self._state = NULL
 


### PR DESCRIPTION
Hello, I stumble upon limitation of lupa library.

I some cases already created `lua_State` required to be used. But there is no possibility to pass pointer to `lua_State` in `LuaRuntime`. For example Wireshark has embedded Lua interpreter and this interpreter has bindings to Wireshark API. I wanted to write plugin (dissector) using Python because it is much more convenient than Lua for me (a lot libraries, familiar syntax, good IDE, etc). So it is not very hard to start Python interpreter using simple Lua C extensions module but without wrappers like lupa provided, I need to also write these wrappers by myself. So I wrote this simple patch to pass pointer of Lua interpreter into `LuaRuntime` and it works! I think may be it worth to be added to your library. 

Regards