### PR TITLE
Set CFLAGS for Lua build if users don't have it

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -225,6 +225,7 @@ def use_bundled_luajit(path, macros):
     print('Using bundled LuaJIT in %s' % libname)
     print('Building LuaJIT for %r in %s' % (platform, libname))
 
+    build_env = dict(os.environ)
     src_dir = os.path.join(path, "src")
     if platform.startswith('win'):
         build_script = [os.path.join(src_dir, "msvcbuild.bat"), "static"]
@@ -233,7 +234,13 @@ def use_bundled_luajit(path, macros):
         build_script = ["make",  "libluajit.a"]
         lib_file = "libluajit.a"
 
-    output = subprocess.check_output(build_script, cwd=src_dir)
+        if 'CFLAGS' in build_env:
+            if "-fPIC" not in build_env['CFLAGS']:
+                build_env['CFLAGS'] += " -fPIC"
+        else:
+            build_env['CFLAGS'] = "-fPIC"
+
+    output = subprocess.check_output(build_script, cwd=src_dir, env=build_env)
     if lib_file.encode("ascii") not in output:
         print("Building LuaJIT did not report success:")
         print(output.decode().strip())


### PR DESCRIPTION
When I attempt to build the current git master on linux, I get a link error:
```
/usr/bin/ld: /tmp/pip-req-build-qmhpkr3b/third-party/luajit20/src/libluajit.a(lj_err.o): relocation R_X86_64_TPOFF32 against `static_uex' can not be used when making a shared object; recompile with -fPIC
```

Command line used:
```
pip install -v --no-clean git+https://github.com/scoder/lupa.git@6e3b2fcdaacfda7c1e43eb3c5dfc97c96906b00a --global-option="--use-bundle"
```

So I added -fPIC to the CFLAGS variable when building the bundled luajit.