### PR TITLE
Install Cython from setup.py before building package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -490,7 +490,7 @@ setup(
     ],
 
     packages=['lupa'],
-    build_requires=['Cython>=0.29.28'],
+    setup_requires=['Cython>=0.29.28'],
     ext_modules=ext_modules,
     libraries=ext_libraries,
     **extra_setup_args


### PR DESCRIPTION
setuptools doesn't have the `build_requires` keywords. Now Cython can be installed by setuptools automatically. But `setup_requires` is [deprecated](https://setuptools.pypa.io/en/latest/references/keywords.html) in favor of the `pyproject.toml` file.