### PR TITLE
Fix bug when installing with `--no-bundle`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -372,7 +372,7 @@ if not configs and not option_no_bundle:
         )
     ]
 if not configs and not option_use_bundle:
-    configs = find_lua_build(no_luajit=option_no_luajit)
+    configs = [find_lua_build(no_luajit=option_no_luajit)]
 if not configs:
     configs = no_lua_error()
 


### PR DESCRIPTION
Wrap the result of finding the system lua version in an array to be compatible with the array of bundled configurations introduced in 2.0