### PR TITLE
Add pyproject.toml build file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -491,7 +491,7 @@ setup(
     ],
 
     packages=['lupa'],
-    build_requires=['Cython>=0.29.28'],
+    setup_requires=['Cython>=0.29.28'],
     ext_modules=ext_modules,
     libraries=ext_libraries,
     **extra_setup_args


### PR DESCRIPTION
This fixes the pip install error when adding Lupa source code as dependency in other packages' pyproject.toml file because Lupa's `setup.py` doesn't install Cython automatically.

Example `pyproject.toml`:

```
[build-system]
requires = ["setuptools"]
build-backend = "setuptools.build_meta"

[project]
name = "mypackage"
version = "0.0.1"
dependencies = [
    "lupa @ git+https://github.com/scoder/lupa.git"
]
```
