### PR TITLE
Add "Programming Language :: Lua" to list of Trove classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -490,6 +490,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Lua',
         'Programming Language :: Other Scripting Engines',
         'Operating System :: OS Independent',
         'Topic :: Software Development',


### PR DESCRIPTION
Dear Stefan,

we added `Programming Language :: Lua` to the designated list of Trove classifiers on behalf of https://github.com/pypa/trove-classifiers/pull/145, so that you can add it to your project metadata as well.

With kind regards,
Andreas.