### PR TITLE
Move dlopenflags handling into new library loader

### DIFF
--- a/lupa/__init__.py
+++ b/lupa/__init__.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-import sys
-
 from contextlib import contextmanager
 
 # Find the implementation with the latest Lua version available.
@@ -80,6 +78,7 @@ def __getattr__(name):
     return attr
 
 
+import sys
 if sys.version_info < (3, 7):
     # Module level "__getattr__" requires Py3.7 or later => import latest Lua now
     _import_newest_lib()

--- a/lupa/__init__.py
+++ b/lupa/__init__.py
@@ -1,12 +1,12 @@
 from __future__ import absolute_import
 
-from contextlib import contextmanager
+from contextlib import contextmanager as _contextmanager
 
 # Find the implementation with the latest Lua version available.
 _newest_lib = None
 
 
-@contextmanager
+@_contextmanager
 def allow_lua_module_loading():
     """
     A context manager for enabling binary Lua module loading when importing Lua.
@@ -14,6 +14,7 @@ def allow_lua_module_loading():
     This can only be used once within a Python runtime and must wrap the import of the
     ``lupa.*`` Lua module, e.g.::
 
+        import lupa
         with lupa.allow_lua_module_loading()
             from lupa import lua54
 

--- a/lupa/__init__.py
+++ b/lupa/__init__.py
@@ -11,7 +11,13 @@ def eager_global_linking():
     try:
         from os import RTLD_NOW, RTLD_GLOBAL
     except ImportError:
-        from DLFCN import RTLD_NOW, RTLD_GLOBAL  # Py2.7
+        try:
+            from DLFCN import RTLD_NOW, RTLD_GLOBAL  # Py2.7
+        except ImportError:
+            # MS-Windows does not have dlopen-flags.
+            yield
+            return
+
     dlopen_flags = RTLD_NOW | RTLD_GLOBAL
 
     import sys

--- a/lupa/__init__.py
+++ b/lupa/__init__.py
@@ -7,7 +7,7 @@ _newest_lib = None
 
 
 @contextmanager
-def eager_global_linking():
+def allow_lua_module_loading():
     try:
         from os import RTLD_NOW, RTLD_GLOBAL
     except ImportError:


### PR DESCRIPTION
The C library is no longer dynamically loaded directly when _lupa is imported, so we need to move the special handling of dlopenflags into the _import_newest_lib() function in order to ensure they are set when the lupa C extension is dlopened.

Closes https://github.com/scoder/lupa/issues/246