### PR TITLE
Add 'name' and 'mode' arguments to LuaRuntime.{eval,execute,compile}

### DIFF
--- a/lupa/luaapi.pxd
+++ b/lupa/luaapi.pxd
@@ -316,9 +316,10 @@ cdef extern from "lauxlib.h" nogil:
     int luaL_ref (lua_State *L, int t)
     void luaL_unref (lua_State *L, int t, int ref)
 
-    int luaL_loadfile (lua_State *L, char *filename)
-    int luaL_loadbuffer (lua_State *L, char *buff, size_t sz, char *name)
-    int luaL_loadstring (lua_State *L, char *s)
+    int luaL_loadfile (lua_State *L, const char *filename)
+    int luaL_loadbuffer (lua_State *L, const char *buff, size_t sz, const char *name)
+    int luaL_loadbufferx (lua_State *L, const char *buff, size_t sz, const char *name, const char *mode)
+    int luaL_loadstring (lua_State *L, const char *s)
 
     lua_State *luaL_newstate ()
 
@@ -450,6 +451,7 @@ cdef extern from * nogil:
 
     #if LUA_VERSION_NUM < 502
     #define lua_tointegerx(L, i, isnum) (*(isnum) = lua_isnumber(L, i), lua_tointeger(L, i))
+    #define luaL_loadbufferx(L, buff, sz, name, mode)  (((void)mode), luaL_loadbuffer(L, buff, sz, name))
     #endif
 
     #if LUA_VERSION_NUM >= 504

--- a/lupa/tests/test.py
+++ b/lupa/tests/test.py
@@ -129,6 +129,14 @@ class TestLuaRuntime(SetupLuaRuntimeMixin, LupaTestCase):
     def test_eval_args_multi(self):
         self.assertEqual((1, 2, 3), self.lua.eval('...', 1, 2, 3))
 
+    def test_eval_name_mode(self):
+        self.assertEqual(2, self.lua.eval('1+1', name='plus', mode='t'))
+
+    def test_eval_mode_error(self):
+        if self.lupa.LUA_VERSION < (5, 2):
+            raise unittest.SkipTest("needs lua 5.2+")
+        self.assertRaises(self.lupa.LuaSyntaxError, self.lua.eval, '1+1', name='plus', mode='b')
+
     def test_eval_error(self):
         self.assertRaises(self.lupa.LuaError, self.lua.eval, '<INVALIDCODE>')
 
@@ -155,6 +163,14 @@ class TestLuaRuntime(SetupLuaRuntimeMixin, LupaTestCase):
 
     def test_execute(self):
         self.assertEqual(2, self.lua.execute('return 1+1'))
+
+    def test_execute_mode(self):
+        self.assertEqual(2, self.lua.execute('return 1+1', name='return_plus', mode='t'))
+
+    def test_execute_mode_error(self):
+        if self.lupa.LUA_VERSION < (5, 2):
+            raise unittest.SkipTest("needs lua 5.2+")
+        self.assertRaises(self.lupa.LuaSyntaxError, self.lua.execute, 'return 1+1', name='plus', mode='b')
 
     def test_execute_function(self):
         self.assertEqual(3, self.lua.execute('f = function(i) return i+1 end; return f(2)'))
@@ -919,6 +935,12 @@ class TestLuaRuntime(SetupLuaRuntimeMixin, LupaTestCase):
     def test_compile(self):
         lua_func = self.lua.compile('return 1 + 2')
         self.assertEqual(lua_func(), 3)
+        lua_func = self.lua.compile('return 3 + 2', mode='t')
+        self.assertEqual(lua_func(), 5)
+        lua_func = self.lua.compile('return 1 + 3', name='huhu')
+        self.assertEqual(lua_func(), 4)
+        lua_func = self.lua.compile('return 2 + 3', name='huhu', mode='t')
+        self.assertEqual(lua_func(), 5)
         self.assertRaises(self.lupa.LuaSyntaxError, self.lua.compile, 'function awd()')
 
 


### PR DESCRIPTION
These allow finer control of input and debug output.

Closes https://github.com/scoder/lupa/issues/248