### PR TITLE
Build with LUA_WITH_DLOPEN also in cibuildwheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,10 +19,11 @@ LD = "gcc-ld"
 AR = "gcc-ar"
 NM = "gcc-nm"
 RANLIB = "gcc-ranlib"
+LUPA_WITH_LUA_DLOPEN = "true"
 
 [[tool.cibuildwheel.overrides]]
 select = "*aarch64"
-environment = {CFLAGS = "-O3 -g1 -pipe -fPIC -flto -march=armv8-a -mtune=cortex-a72", AR = "gcc-ar", NM = "gcc-nm", RANLIB = "gcc-ranlib", LDFLAGS = "-fPIC -flto", LUPA_USE_BUNDLE = "true" }
+environment = {CFLAGS = "-O3 -g1 -pipe -fPIC -flto -march=armv8-a -mtune=cortex-a72", AR = "gcc-ar", NM = "gcc-nm", RANLIB = "gcc-ranlib", LDFLAGS = "-fPIC -flto", LUPA_USE_BUNDLE = "true", LUPA_WITH_LUA_DLOPEN = "true"}
 
 [tool.cibuildwheel.windows]
 archs = ["AMD64", "x86"]
@@ -34,3 +35,6 @@ test-command = "python -c \"import lupa\" && python -c \"import lupa.lua54\" && 
 # so additional arm64 wheels would suffice.  However, since the library build uses a mixed
 # amd64/arm64 setup, we build universal2 wheels regardless.
 archs = ["x86_64", "arm64", "universal2"]
+
+[tool.cibuildwheel.macos.environment]
+LUPA_WITH_LUA_DLOPEN = "true"


### PR DESCRIPTION
Fixes #278

I think that was dropped when CI was moved to `cibuildwheel`. https://github.com/scoder/lupa/commit/df96f76817133af827a7bac3d89c99315e6e751e added this in 2013, but during the move, this env var was not set in the `cibuildwheel` configuration https://github.com/scoder/lupa/commit/86ffdc0cb6718e230a2d3e78e07b5e4f923ed2be.

cc @a-hurst @mcaccin 