### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -218,7 +218,7 @@ Python does, so the Lua operations ``obj[x]`` and ``obj.x`` both map
 to indexing.  To decide which Python protocol to use for Lua wrapped
 objects, Lupa employs a simple heuristic.
 
-Pratically all Python objects allow attribute access, so if the object
+Practically all Python objects allow attribute access, so if the object
 also has a ``__getitem__`` method, it is preferred when turning it
 into an indexable Lua object.  Otherwise, it becomes a simple object
 that uses attribute access for indexing from inside Lua.

--- a/lupa/luaapi.pxd
+++ b/lupa/luaapi.pxd
@@ -235,7 +235,7 @@ cdef extern from "lua.h" nogil:
     ctypedef struct lua_Debug  # activation record
 
 
-    # Functions to be called by the debuger in specific events
+    # Functions to be called by the debugger in specific events
     ctypedef void (*lua_Hook) (lua_State *L, lua_Debug *ar)
 
     int lua_getstack (lua_State *L, int level, lua_Debug *ar)

--- a/lupa/tests/test.py
+++ b/lupa/tests/test.py
@@ -2072,7 +2072,7 @@ class TestThreading(LupaTestCase):
         self.assertEqual(type(result_bytes), type(empty_bytes_string))
         self.assertEqual(image_size*image_size//8, len(result_bytes))
 
-        # plausability checks - make sure it's not all white or all black
+        # plausibility checks - make sure it's not all white or all black
         self.assertEqual('\0'.encode('ASCII')*(image_size//8//2),
                          result_bytes[:image_size//8//2])
         self.assertTrue(b'\xFF' in result_bytes)


### PR DESCRIPTION
Fix typos discovered by codespell - https://pypi.org/project/codespell

% `codespell --skip="./third-party/*"`
```
./README.rst:221: Pratically ==> Practically
./lupa/luaapi.pxd:238: debuger ==> debugger
./lupa/tests/test.py:2075: plausability ==> plausibility
```
% `codespell --skip="./third-party/*" --write-changes`